### PR TITLE
Update price per share on reporting strategy

### DIFF
--- a/src/mappings/strategyMappings.ts
+++ b/src/mappings/strategyMappings.ts
@@ -1,4 +1,4 @@
-import { Address, ethereum, BigInt, log } from '@graphprotocol/graph-ts';
+import { log } from '@graphprotocol/graph-ts';
 import { Harvested as HarvestedEvent } from '../../generated/templates/Vault/Strategy';
 import * as strategyLibrary from '../utils/strategy';
 import { getOrCreateTransactionFromEvent } from '../utils/transaction';

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -36,7 +36,7 @@ export function handleStrategyAdded(event: StrategyAddedEvent): void {
 }
 
 export function handleStrategyReported(event: StrategyReportedEvent): void {
-  log.debug('[Vault mappings] Handle deposit', []);
+  log.debug('[Vault mappings] Handle strategy reported', []);
   let ethTransaction = getOrCreateTransactionFromEvent(
     event,
     'StrategyReportedEvent'
@@ -52,6 +52,18 @@ export function handleStrategyReported(event: StrategyReportedEvent): void {
     event.params.debtAdded,
     event.params.debtLimit,
     event
+  );
+
+  log.info(
+    '[Vault mappings] Updating price per share (strategy reported): {}',
+    [event.transaction.hash.toHexString()]
+  );
+  let vaultContractAddress = event.address;
+  let vaultContract = VaultContract.bind(vaultContractAddress);
+  vaultLibrary.strategyReported(
+    ethTransaction,
+    vaultContractAddress,
+    vaultContract.pricePerShare()
   );
 }
 

--- a/src/utils/vault/vault-update.ts
+++ b/src/utils/vault/vault-update.ts
@@ -150,3 +150,29 @@ export function withdraw(
   vault.save();
   return newVaultUpdate;
 }
+
+export function strategyReported(
+  vault: Vault,
+  latestVaultUpdate: VaultUpdate,
+  transaction: Transaction,
+  pricePerShare: BigInt
+): VaultUpdate {
+  let vaultUpdateId = buildIdFromVaultAndTransaction(vault, transaction);
+  let newVaultUpdate = createVaultUpdate(
+    vaultUpdateId,
+    vault,
+    transaction,
+    latestVaultUpdate.tokensDeposited,
+    latestVaultUpdate.tokensWithdrawn,
+    latestVaultUpdate.sharesMinted,
+    latestVaultUpdate.sharesBurnt,
+    pricePerShare,
+    latestVaultUpdate.returnsGenerated,
+    latestVaultUpdate.totalFees,
+    latestVaultUpdate.managementFees,
+    latestVaultUpdate.performanceFees
+  );
+  vault.latestUpdate = newVaultUpdate.id;
+  vault.save();
+  return newVaultUpdate;
+}

--- a/src/utils/vault/vault.ts
+++ b/src/utils/vault/vault.ts
@@ -285,3 +285,21 @@ export function transfer(
     transaction
   );
 }
+
+export function strategyReported(
+  transaction: Transaction,
+  vaultAddress: Address,
+  pricePerShare: BigInt
+): void {
+  let vault = getOrCreate(vaultAddress, transaction.hash.toHexString());
+  let latestVaultUpdate = VaultUpdate.load(vault.latestUpdate);
+  // The latest vault update should exist
+  if (latestVaultUpdate !== null) {
+    vaultUpdateLibrary.strategyReported(
+      vault,
+      latestVaultUpdate as VaultUpdate,
+      transaction,
+      pricePerShare
+    );
+  }
+}

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -53,9 +53,13 @@ templates:
         - VaultUpdate
         - Transfer
         - Account
-        - AccountUpdate
-        - AccountVaultBalance
+        - Deposit
+        - VaultUpdate
+        - Transfer
+        - Transaction
         - Token
+        - AccountVaultPosition
+        - AccountVaultPositionUpdate
       abis:
         - name: Vault
           file: ./abis/Vault.json


### PR DESCRIPTION
It includes:

- Update price per share (creating a new VaultUpdate item) on event StrategyReported.

Changes synced in subgraph:

https://thegraph.com/explorer/subgraph/salazarguille/yearn-vaults-v2-subgraph-mainnet?query=Account%20Updates