### PR TITLE
fix: update balanceShares on AccountVaultPosition on transfers to/from the account

### DIFF
--- a/src/utils/account/vault-position.ts
+++ b/src/utils/account/vault-position.ts
@@ -194,6 +194,7 @@ export function transfer(
     toAccountVaultPosition.balanceShares = toAccountVaultPosition.balanceShares.plus(
       shareAmount
     );
+    toAccountVaultPosition.save();
   } else {
     toAccountVaultPosition = makeAccountVaultPosition(
       vaultContract,
@@ -203,8 +204,8 @@ export function transfer(
       shareAmount,
       transaction
     );
+    toAccountVaultPosition.save();
   }
-  toAccountVaultPosition.save();
 }
 
 function makeAccountVaultPosition(


### PR DESCRIPTION
fixes https://github.com/yearn/yearn-vaults-v2-subgraph/issues/54 and https://github.com/yearn/yearn-vaults-v2-subgraph/issues/53

* fix balanceShares not updating when a user transfers into/out of a vault
* create an AccountVaultPosition when a user transfers into a vault without previously depositing

I'm not sure we want to store `balanceTokens` on `AccountVaultPosition` because won't it always be out of date as the `pricePerShare` changes? We should just derive this property from numShares * latestVaultPosition.pricePerShare? Not sure

Also I had to do the dance around the u8 in `getBalancePosition` because I was getting this error when deploying the subgraph: 

```
{
  "data": {
    "indexingStatusForCurrentVersion": {
      "fatalError": {
        "message": "out of range integral type conversion attempted\twasm backtrace:\t    0: 0x256e - <unknown>!src/utils/account/vault-position/getBalancePosition\t    1: 0x2873 - <unknown>!src/utils/account/vault-position/deposit\t    2: 0x2ac0 - <unknown>!src/utils/vault/vault/deposit\t    3: 0x2bbb - <unknown>!src/mappings/vaultMappings/handleDepositWithAmount\t in handler handleDepositWithAmount at block #11579817 (edbc0c6a8a3946bd0b01493398b73a57516e6f5258e325b86c525e942212644e)"
      },
      "nonFatalErrors": [],
      "subgraph": "QmTcCeGHq8xD4uPF2KDHZxRxWgsABgLxtGcEkapqwZFHnR"
    }
  }
}
```