### PR TITLE
feat: add data for vault total earnings calculations

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -346,13 +346,22 @@ export class Vault extends Entity {
     this.set("balanceTokens", Value.fromBigInt(value));
   }
 
-  get balanceTokensIdle(): BigInt {
-    let value = this.get("balanceTokensIdle");
+  get balanceTotalTokensDeposited(): BigInt {
+    let value = this.get("balanceTotalTokensDeposited");
     return value.toBigInt();
   }
 
-  set balanceTokensIdle(value: BigInt) {
-    this.set("balanceTokensIdle", Value.fromBigInt(value));
+  set balanceTotalTokensDeposited(value: BigInt) {
+    this.set("balanceTotalTokensDeposited", Value.fromBigInt(value));
+  }
+
+  get balanceTotalTokensWithdrawn(): BigInt {
+    let value = this.get("balanceTotalTokensWithdrawn");
+    return value.toBigInt();
+  }
+
+  set balanceTotalTokensWithdrawn(value: BigInt) {
+    this.set("balanceTotalTokensWithdrawn", Value.fromBigInt(value));
   }
 
   get balanceTokensInvested(): BigInt {
@@ -1540,112 +1549,6 @@ export class StrategyReport extends Entity {
 
   set debtLimit(value: BigInt) {
     this.set("debtLimit", Value.fromBigInt(value));
-  }
-}
-
-export class StrategyReportResult extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(
-      id !== null,
-      "Cannot save StrategyReportResult entity without an ID"
-    );
-    assert(
-      id.kind == ValueKind.STRING,
-      "Cannot save StrategyReportResult entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.'
-    );
-    store.set("StrategyReportResult", id.toString(), this);
-  }
-
-  static load(id: string): StrategyReportResult | null {
-    return store.get("StrategyReportResult", id) as StrategyReportResult | null;
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    return value.toString();
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get timestamp(): BigInt {
-    let value = this.get("timestamp");
-    return value.toBigInt();
-  }
-
-  set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value));
-  }
-
-  get blockNumber(): BigInt {
-    let value = this.get("blockNumber");
-    return value.toBigInt();
-  }
-
-  set blockNumber(value: BigInt) {
-    this.set("blockNumber", Value.fromBigInt(value));
-  }
-
-  get report(): string {
-    let value = this.get("report");
-    return value.toString();
-  }
-
-  set report(value: string) {
-    this.set("report", Value.fromString(value));
-  }
-
-  get startTimestamp(): BigInt {
-    let value = this.get("startTimestamp");
-    return value.toBigInt();
-  }
-
-  set startTimestamp(value: BigInt) {
-    this.set("startTimestamp", Value.fromBigInt(value));
-  }
-
-  get endTimestamp(): BigInt {
-    let value = this.get("endTimestamp");
-    return value.toBigInt();
-  }
-
-  set endTimestamp(value: BigInt) {
-    this.set("endTimestamp", Value.fromBigInt(value));
-  }
-
-  get duration(): BigDecimal {
-    let value = this.get("duration");
-    return value.toBigDecimal();
-  }
-
-  set duration(value: BigDecimal) {
-    this.set("duration", Value.fromBigDecimal(value));
-  }
-
-  get durationPr(): BigDecimal {
-    let value = this.get("durationPr");
-    return value.toBigDecimal();
-  }
-
-  set durationPr(value: BigDecimal) {
-    this.set("durationPr", Value.fromBigDecimal(value));
-  }
-
-  get apr(): BigDecimal {
-    let value = this.get("apr");
-    return value.toBigDecimal();
-  }
-
-  set apr(value: BigDecimal) {
-    this.set("apr", Value.fromBigDecimal(value));
   }
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -2,7 +2,7 @@
 ## Naming Conventions
 # Certain prefixes may be used to indicate a particular type of value.
 #   * total - indicates this is a cumulative value (e.g. totalSharesMinted, totalGrossReturns)
-#   * balance - indicates this is a spot balance (e.g. balanceTokensInvested, balanceTokensIdle)
+#   * balance - indicates this is a spot balance (e.g. balanceTokensInvested)
 #   * delta - indicates this value is the difference between the prior state and the current state (e.g. deltaPricePerShare)
 # Use plurals when referring to Tokens or Shares (e.g. totalShares, balanceTokens)
 
@@ -107,8 +107,10 @@ type Vault @entity {
   tags: [String!]!
   "Balance of Tokens in the Vault and its Strategies"
   balanceTokens: BigInt!
-  "Current idle Token balance"
-  balanceTokensIdle: BigInt! # Tokens in the Vault contract
+  "All time total number of tokens that have been deposited into the vault"
+  balanceTotalTokensDeposited: BigInt!
+  "All time total number of tokens that have been withdrawn from the vault"
+  balanceTotalTokensWithdrawn: BigInt!
   "Balance of Tokens invested into Strategies"
   balanceTokensInvested: BigInt!
   "Deposit limit for Tokens in the Vault"

--- a/schema.graphql
+++ b/schema.graphql
@@ -107,9 +107,9 @@ type Vault @entity {
   tags: [String!]!
   "Balance of Tokens in the Vault and its Strategies"
   balanceTokens: BigInt!
-  "All time total number of tokens that have been deposited into the vault"
+  "Lifetime total number of tokens that have been deposited into the vault"
   balanceTotalTokensDeposited: BigInt!
-  "All time total number of tokens that have been withdrawn from the vault"
+  "Lifetime total number of tokens that have been withdrawn from the vault"
   balanceTotalTokensWithdrawn: BigInt!
   "Balance of Tokens invested into Strategies"
   balanceTokensInvested: BigInt!

--- a/src/utils/account/vault-position.ts
+++ b/src/utils/account/vault-position.ts
@@ -24,9 +24,9 @@ export function getBalancePosition(
   let accountAddress = Address.fromString(account.id);
   let accountBalance = vaultContract.balanceOf(accountAddress);
   // (vault.balanceOf(account) * (vault.pricePerShare() / 10**vault.decimals()))
-  return accountBalance.times(
-    pricePerShare.div(BigInt.fromI32(10).pow(decimals as u8))
-  );
+  let u8Decimals = u8(decimals.toI32());
+  let divisor = BigInt.fromI32(10).pow(u8Decimals);
+  return accountBalance.times(pricePerShare.div(divisor));
 }
 
 export class VaultPositionResponse {

--- a/src/utils/vault/vault-update.ts
+++ b/src/utils/vault/vault-update.ts
@@ -146,6 +146,9 @@ export function withdraw(
   );
   vault.sharesSupply = vault.sharesSupply.minus(sharesBurnt);
   vault.balanceTokens = vault.balanceTokens.minus(withdrawnAmount);
+  vault.balanceTotalTokensWithdrawn = vault.balanceTotalTokensWithdrawn.plus(
+    withdrawnAmount
+  );
   vault.latestUpdate = newVaultUpdate.id;
   vault.save();
   return newVaultUpdate;

--- a/src/utils/vault/vault.ts
+++ b/src/utils/vault/vault.ts
@@ -40,7 +40,8 @@ const createNewVaultFromAddress = (
   // empty at creation
   vaultEntity.tags = [];
   vaultEntity.balanceTokens = BIGINT_ZERO;
-  vaultEntity.balanceTokensIdle = BIGINT_ZERO;
+  vaultEntity.balanceTotalTokensDeposited = BIGINT_ZERO;
+  vaultEntity.balanceTotalTokensWithdrawn = BIGINT_ZERO;
   vaultEntity.balanceTokensInvested = BIGINT_ZERO;
 
   vaultEntity.tokensDepositLimit = BIGINT_ZERO;
@@ -190,7 +191,9 @@ export function deposit(
 
   vault.latestUpdate = vaultUpdate.id;
   vault.balanceTokens = vault.balanceTokens.plus(depositedAmount);
-  vault.balanceTokensIdle = vault.balanceTokensIdle.plus(depositedAmount);
+  vault.balanceTotalTokensDeposited = vault.balanceTotalTokensDeposited.plus(
+    depositedAmount
+  );
   vault.sharesSupply = vault.sharesSupply.plus(sharesMinted);
 
   vault.save();


### PR DESCRIPTION
To calculate the total lifetime earnings for each vault you need to use the formula: 

Earnings = current tokens - deposited tokens + withdrawn tokens

This PR adds two properties to the schema that track the total deposits/withdrawals on vaults. 

`balanceTokensIdle` was effectively doing this for the deposits but it didn't look liked it was being used so I renamed it to be clearer. 