### PR TITLE
feat: add balancePosition for vaultUpdates and implement the returnsGenerated field

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -521,6 +521,15 @@ export class VaultUpdate extends Entity {
     this.set("sharesBurnt", Value.fromBigInt(value));
   }
 
+  get balancePosition(): BigInt {
+    let value = this.get("balancePosition");
+    return value.toBigInt();
+  }
+
+  set balancePosition(value: BigInt) {
+    this.set("balancePosition", Value.fromBigInt(value));
+  }
+
   get pricePerShare(): BigInt {
     let value = this.get("pricePerShare");
     return value.toBigInt();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:mainnet": "yarn prepare:mainnet && graph build",
     "thegraph:deploy:kovan": "yarn build:kovan && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ salazarguille/yearn-vaults-v2-subgraph-kovan",
     "thegraph:deploy:rinkeby": "yarn build:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ salazarguille/yearn-vaults-v2-subgraph-rinkeby",
-    "thegraph:deploy:mainnet": "yarn build:mainnet && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ tomprsn/yearn-vaults-v2-subgraph-mainnet",
+    "thegraph:deploy:mainnet": "yarn build:mainnet && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ salazarguille/yearn-vaults-v2-subgraph-mainnet",
     "create-local": "graph create --node http://127.0.0.1:8020/ yearn-vaults-v2/subgraph",
     "remove-local": "graph remove --node http://127.0.0.1:8020/ yearn-vaults-v2/subgraph",
     "deploy-local": "yarn build:mainnet && graph deploy --node http://127.0.0.1:8020/ --ipfs http://localhost:5001 yearn-vaults-v2/subgraph",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:mainnet": "yarn prepare:mainnet && graph build",
     "thegraph:deploy:kovan": "yarn build:kovan && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ salazarguille/yearn-vaults-v2-subgraph-kovan",
     "thegraph:deploy:rinkeby": "yarn build:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ salazarguille/yearn-vaults-v2-subgraph-rinkeby",
-    "thegraph:deploy:mainnet": "yarn build:mainnet && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ salazarguille/yearn-vaults-v2-subgraph-mainnet",
+    "thegraph:deploy:mainnet": "yarn build:mainnet && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ tomprsn/yearn-vaults-v2-subgraph-mainnet",
     "create-local": "graph create --node http://127.0.0.1:8020/ yearn-vaults-v2/subgraph",
     "remove-local": "graph remove --node http://127.0.0.1:8020/ yearn-vaults-v2/subgraph",
     "deploy-local": "yarn build:mainnet && graph deploy --node http://127.0.0.1:8020/ --ipfs http://localhost:5001 yearn-vaults-v2/subgraph",

--- a/schema.graphql
+++ b/schema.graphql
@@ -150,6 +150,8 @@ type VaultUpdate @entity {
   sharesMinted: BigInt!
   "Sum of Shares burnt over all time"
   sharesBurnt: BigInt!
+  "The current balance position defined as: (vault.totalAssets() * (vault.pricePerShare() / 10**vault.decimals()))."
+  balancePosition: BigInt!
 
   ### PERFORMANCE
 

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -1,4 +1,4 @@
-import { Address, log } from '@graphprotocol/graph-ts';
+import { Address, BigInt, log } from '@graphprotocol/graph-ts';
 import {
   StrategyAdded as StrategyAddedEvent,
   StrategyReported as StrategyReportedEvent,
@@ -63,6 +63,7 @@ export function handleStrategyReported(event: StrategyReportedEvent): void {
   let vaultContract = VaultContract.bind(vaultContractAddress);
   vaultLibrary.strategyReported(
     ethTransaction,
+    vaultContract,
     vaultContractAddress,
     vaultContract.pricePerShare()
   );

--- a/src/utils/vault/vault-update.ts
+++ b/src/utils/vault/vault-update.ts
@@ -53,12 +53,12 @@ function createVaultUpdate(
   vaultUpdate.totalFees = totalFees;
   vaultUpdate.managementFees = managementFees;
   vaultUpdate.performanceFees = performanceFees;
+  vaultUpdate.balancePosition = balancePosition;
 
-  var tokenBalance = tokensDeposited.minus(tokensWithdrawn);
-  if (tokenBalance.gt(balancePosition)) {
-    vaultUpdate.returnsGenerated = BIGINT_ZERO;
+  if (vault.balanceTokens.gt(balancePosition)) {
+    vaultUpdate.returnsGenerated = balancePosition;
   } else {
-    vaultUpdate.returnsGenerated = balancePosition.minus(tokenBalance);
+    vaultUpdate.returnsGenerated = balancePosition.minus(vault.balanceTokens);
   }
 
   vaultUpdate.save();

--- a/src/utils/vault/vault-update.ts
+++ b/src/utils/vault/vault-update.ts
@@ -32,10 +32,10 @@ function createVaultUpdate(
   sharesMinted: BigInt,
   sharesBurnt: BigInt,
   pricePerShare: BigInt,
-  returnsGenerated: BigInt,
   totalFees: BigInt,
   managementFees: BigInt,
-  performanceFees: BigInt
+  performanceFees: BigInt,
+  balancePosition: BigInt
 ): VaultUpdate {
   log.debug('[VaultUpdate] Creating vault update with id {}', [vault.id]);
   let vaultUpdate = new VaultUpdate(id);
@@ -50,10 +50,17 @@ function createVaultUpdate(
   vaultUpdate.sharesBurnt = sharesBurnt;
   // Performance
   vaultUpdate.pricePerShare = pricePerShare;
-  vaultUpdate.returnsGenerated = returnsGenerated;
   vaultUpdate.totalFees = totalFees;
   vaultUpdate.managementFees = managementFees;
   vaultUpdate.performanceFees = performanceFees;
+
+  var tokenBalance = tokensDeposited.minus(tokensWithdrawn);
+  if (tokenBalance.gt(balancePosition)) {
+    vaultUpdate.returnsGenerated = BIGINT_ZERO;
+  } else {
+    vaultUpdate.returnsGenerated = balancePosition.minus(tokenBalance);
+  }
+
   vaultUpdate.save();
   return vaultUpdate;
 }
@@ -63,7 +70,8 @@ export function firstDeposit(
   transaction: Transaction,
   depositedAmount: BigInt,
   sharesMinted: BigInt,
-  pricePerShare: BigInt
+  pricePerShare: BigInt,
+  balancePosition: BigInt
 ): VaultUpdate {
   log.debug('[VaultUpdate] First deposit', []);
   let vaultUpdateId = buildIdFromVaultAndTransaction(vault, transaction);
@@ -82,7 +90,7 @@ export function firstDeposit(
       BIGINT_ZERO,
       BIGINT_ZERO,
       BIGINT_ZERO,
-      BIGINT_ZERO
+      balancePosition
     );
   }
 
@@ -94,7 +102,8 @@ export function deposit(
   transaction: Transaction,
   depositedAmount: BigInt,
   sharesMinted: BigInt,
-  pricePerShare: BigInt
+  pricePerShare: BigInt,
+  balancePosition: BigInt
 ): VaultUpdate {
   log.debug('[VaultUpdate] Deposit', []);
   let vaultUpdateId = buildIdFromVaultAndTransaction(vault, transaction);
@@ -111,10 +120,10 @@ export function deposit(
       latestVaultUpdate.sharesMinted.plus(sharesMinted),
       latestVaultUpdate.sharesBurnt,
       pricePerShare,
-      latestVaultUpdate.returnsGenerated,
       latestVaultUpdate.totalFees,
       latestVaultUpdate.managementFees,
-      latestVaultUpdate.performanceFees
+      latestVaultUpdate.performanceFees,
+      balancePosition
     );
   }
 
@@ -127,7 +136,8 @@ export function withdraw(
   pricePerShare: BigInt,
   withdrawnAmount: BigInt,
   sharesBurnt: BigInt,
-  transaction: Transaction
+  transaction: Transaction,
+  balancePosition: BigInt
 ): VaultUpdate {
   let vaultUpdateId = buildIdFromVaultAndTransaction(vault, transaction);
   let newVaultUpdate = createVaultUpdate(
@@ -139,10 +149,10 @@ export function withdraw(
     latestVaultUpdate.sharesMinted,
     latestVaultUpdate.sharesBurnt.plus(sharesBurnt),
     pricePerShare,
-    latestVaultUpdate.returnsGenerated,
     latestVaultUpdate.totalFees,
     latestVaultUpdate.managementFees,
-    latestVaultUpdate.performanceFees
+    latestVaultUpdate.performanceFees,
+    balancePosition
   );
   vault.sharesSupply = vault.sharesSupply.minus(sharesBurnt);
   vault.balanceTokens = vault.balanceTokens.minus(withdrawnAmount);
@@ -155,7 +165,8 @@ export function strategyReported(
   vault: Vault,
   latestVaultUpdate: VaultUpdate,
   transaction: Transaction,
-  pricePerShare: BigInt
+  pricePerShare: BigInt,
+  balancePosition: BigInt
 ): VaultUpdate {
   let vaultUpdateId = buildIdFromVaultAndTransaction(vault, transaction);
   let newVaultUpdate = createVaultUpdate(
@@ -167,10 +178,10 @@ export function strategyReported(
     latestVaultUpdate.sharesMinted,
     latestVaultUpdate.sharesBurnt,
     pricePerShare,
-    latestVaultUpdate.returnsGenerated,
     latestVaultUpdate.totalFees,
     latestVaultUpdate.managementFees,
-    latestVaultUpdate.performanceFees
+    latestVaultUpdate.performanceFees,
+    balancePosition
   );
   vault.latestUpdate = newVaultUpdate.id;
   vault.save();


### PR DESCRIPTION
The purpose of this change is to be able to calculate vault earnings at any given point in time

* filled in the value of `returnsGenerated` for `VaultUpdate`, previously it was always 0. I assume what I have implemented is what this field was intended for, if not we can just make a new `earnings` field
* add `balancePosition` to `VaultUpdate`, similar to how it is used for `Account`. Not necessary to be stored but I added it so it can be queried, happy to remove if we don't think it'll be useful, it'll still be needed in the mappings to calculate `returnsGenerated`