### PR TITLE
Adding New Entities and Improvements/Fixes

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,5 +1,6 @@
 {
   "startBlock": "11390000",
+  "startBlockRegistryV2": "12045550",
   "network": "mainnet",
   "Registry": "0xe15461b18ee31b7379019dc523231c57d1cbc18c",
   "RegistryV2": "0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804"

--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -42,6 +42,15 @@ export class Transaction extends Entity {
     this.set("id", Value.fromString(value));
   }
 
+  get logIndex(): BigInt {
+    let value = this.get("logIndex");
+    return value.toBigInt();
+  }
+
+  set logIndex(value: BigInt) {
+    this.set("logIndex", Value.fromBigInt(value));
+  }
+
   get event(): string {
     let value = this.get("event");
     return value.toString();
@@ -200,6 +209,81 @@ export class Token extends Entity {
   }
 }
 
+export class Registry extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id !== null, "Cannot save Registry entity without an ID");
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save Registry entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("Registry", id.toString(), this);
+  }
+
+  static load(id: string): Registry | null {
+    return store.get("Registry", id) as Registry | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
+    return value.toBigInt();
+  }
+
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
+  }
+
+  get blockNumber(): BigInt {
+    let value = this.get("blockNumber");
+    return value.toBigInt();
+  }
+
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
+  }
+
+  get transaction(): string {
+    let value = this.get("transaction");
+    return value.toString();
+  }
+
+  set transaction(value: string) {
+    this.set("transaction", Value.fromString(value));
+  }
+
+  get vaults(): Array<string> | null {
+    let value = this.get("vaults");
+    if (value === null || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toStringArray();
+    }
+  }
+
+  set vaults(value: Array<string> | null) {
+    if (value === null) {
+      this.unset("vaults");
+    } else {
+      this.set("vaults", Value.fromStringArray(value as Array<string>));
+    }
+  }
+}
+
 export class Vault extends Entity {
   constructor(id: string) {
     super();
@@ -237,6 +321,15 @@ export class Vault extends Entity {
 
   set transaction(value: string) {
     this.set("transaction", Value.fromString(value));
+  }
+
+  get registry(): string {
+    let value = this.get("registry");
+    return value.toString();
+  }
+
+  set registry(value: string) {
+    this.set("registry", Value.fromString(value));
   }
 
   get token(): string {
@@ -1148,6 +1241,15 @@ export class AccountVaultPositionUpdate extends Entity {
     this.set("id", Value.fromString(value));
   }
 
+  get order(): BigInt {
+    let value = this.get("order");
+    return value.toBigInt();
+  }
+
+  set order(value: BigInt) {
+    this.set("order", Value.fromBigInt(value));
+  }
+
   get timestamp(): BigInt {
     let value = this.get("timestamp");
     return value.toBigInt();
@@ -1558,6 +1660,130 @@ export class StrategyReport extends Entity {
 
   set debtLimit(value: BigInt) {
     this.set("debtLimit", Value.fromBigInt(value));
+  }
+
+  get results(): Array<string> {
+    let value = this.get("results");
+    return value.toStringArray();
+  }
+
+  set results(value: Array<string>) {
+    this.set("results", Value.fromStringArray(value));
+  }
+}
+
+export class StrategyReportResult extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(
+      id !== null,
+      "Cannot save StrategyReportResult entity without an ID"
+    );
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save StrategyReportResult entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("StrategyReportResult", id.toString(), this);
+  }
+
+  static load(id: string): StrategyReportResult | null {
+    return store.get("StrategyReportResult", id) as StrategyReportResult | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
+    return value.toBigInt();
+  }
+
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
+  }
+
+  get blockNumber(): BigInt {
+    let value = this.get("blockNumber");
+    return value.toBigInt();
+  }
+
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
+  }
+
+  get report(): string {
+    let value = this.get("report");
+    return value.toString();
+  }
+
+  set report(value: string) {
+    this.set("report", Value.fromString(value));
+  }
+
+  get startTimestamp(): BigInt {
+    let value = this.get("startTimestamp");
+    return value.toBigInt();
+  }
+
+  set startTimestamp(value: BigInt) {
+    this.set("startTimestamp", Value.fromBigInt(value));
+  }
+
+  get endTimestamp(): BigInt {
+    let value = this.get("endTimestamp");
+    return value.toBigInt();
+  }
+
+  set endTimestamp(value: BigInt) {
+    this.set("endTimestamp", Value.fromBigInt(value));
+  }
+
+  get duration(): BigDecimal {
+    let value = this.get("duration");
+    return value.toBigDecimal();
+  }
+
+  set duration(value: BigDecimal) {
+    this.set("duration", Value.fromBigDecimal(value));
+  }
+
+  get durationPr(): BigDecimal {
+    let value = this.get("durationPr");
+    return value.toBigDecimal();
+  }
+
+  set durationPr(value: BigDecimal) {
+    this.set("durationPr", Value.fromBigDecimal(value));
+  }
+
+  get apr(): BigDecimal {
+    let value = this.get("apr");
+    return value.toBigDecimal();
+  }
+
+  set apr(value: BigDecimal) {
+    this.set("apr", Value.fromBigDecimal(value));
+  }
+
+  get transaction(): string {
+    let value = this.get("transaction");
+    return value.toString();
+  }
+
+  set transaction(value: string) {
+    this.set("transaction", Value.fromString(value));
   }
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -7,8 +7,10 @@
 # Use plurals when referring to Tokens or Shares (e.g. totalShares, balanceTokens)
 
 type Transaction @entity {
-  "Transaction hash"
+  "Transaction hash + Log Index"
   id: ID!
+  "Log index related to the event. A Transaction might contain multiple events."
+  logIndex: BigInt!
   "The event name / call stacktrace"
   event: String!
   "The transaction sender"
@@ -73,6 +75,19 @@ enum VaultClassification {
 #   transaction: Transaction!
 # }
 
+type Registry @entity {
+  "Registry address"
+  id: ID!
+  "Transaction timestamp"
+  timestamp: BigInt!
+  "Transaction/Block Block number"
+  blockNumber: BigInt!
+  "Ethereum Transaction"
+  transaction: Transaction!
+  "Vaults registered in the registry."
+  vaults: [Vault!]! @derivedFrom(field: "registry")
+}
+
 # TODO:
 # emergency shutdown
 # withdrawal queue
@@ -81,6 +96,8 @@ type Vault @entity {
   id: ID!
   "Ethereum Transaction"
   transaction: Transaction!
+  "The registry address"
+  registry: Registry!
   "Token this Vault will accrue"
   token: Token!
   "Token representing Shares in the Vault"
@@ -281,8 +298,10 @@ type AccountVaultPosition @entity {
 }
 
 type AccountVaultPositionUpdate @entity {
-  "Account-Transaction-Log"
+  "Account-Vault-Order"
   id: ID!
+  "Incremental value for the same account/vault."
+  order: BigInt!
   "Timestamp"
   timestamp: BigInt!
   "Block number"
@@ -379,12 +398,35 @@ type StrategyReport @entity {
   debtLimit: BigInt!
   # "Vault state"
   # vaultUpdate: VaultUpdate!
+  "The results created by this report. They are generated comparing the previous report and the current one."
+  results: [StrategyReportResult!]! @derivedFrom(field: "report")
 
   #### TODO Awaiting updated Vault Yield-Oracles https://github.com/iearn-finance/yearn-vaults/pull/69
   # "12-day EMA of Vault APY as reported by built-in Yield Oracle"
   # apy12dEMA: Int!
   # "50-day EMA of Vault APY as reported by built-in Yield Oracle"
   # apy50dEMA: Int!
+}
+
+type StrategyReportResult @entity {
+  "The Strategy Report Result ID."
+  id: ID!
+  "Timestamp the strategy report was most recently updated."
+  timestamp: BigInt!
+  "Blocknumber the strategy report was most recently updated."
+  blockNumber: BigInt!
+  "The Strategy reference."
+  report: StrategyReport!
+  startTimestamp: BigInt!
+  endTimestamp: BigInt!
+  "The duration (in days) from the previous report."
+  duration: BigDecimal!
+  "Duration percentage rate."
+  durationPr: BigDecimal!
+  "Annual Percentage Rate."
+  apr: BigDecimal!
+  "Ethereum Transaction"
+  transaction: Transaction!
 }
 
 type Harvest @entity {

--- a/src/utils/account/vault-position-update.ts
+++ b/src/utils/account/vault-position-update.ts
@@ -9,27 +9,23 @@ import {
 import { BIGINT_ZERO } from '../constants';
 import * as vaultUpdateLibrary from '../vault/vault-update';
 
-export function buildIdFromAccountHashAndIndex(
-  account: Account,
-  transactionHash: string,
-  transactionIndex: string
-): string {
-  return account.id
-    .concat('-')
-    .concat(transactionHash)
-    .concat('-')
-    .concat(transactionIndex);
+function incrementOrder(order: BigInt): BigInt {
+  return order.plus(BigInt.fromI32(1));
 }
 
-export function buildIdFromAccountAndTransaction(
+export function buildIdFromAccountVaultAndOrder(
   account: Account,
-  transaction: Transaction
+  vault: Vault,
+  newOrder: BigInt
 ): string {
-  return account.id.concat('-'.concat(transaction.id));
+  return account.id.concat(
+    '-'.concat(vault.id.concat('-'.concat(newOrder.toString())))
+  );
 }
 
 export function createAccountVaultPositionUpdate(
   id: string,
+  newOrder: BigInt,
   account: Account,
   vault: Vault,
   accountVaultPositionId: string,
@@ -45,10 +41,11 @@ export function createAccountVaultPositionUpdate(
   balancePosition: BigInt
 ): AccountVaultPositionUpdate {
   log.info(
-    '[VaultPositionUpdate] Creating account {} vault position update with id {}',
-    [account.id, id]
+    '[VaultPositionUpdate] Creating account {} vault position update (order {}) with id {}',
+    [account.id, newOrder.toString(), id]
   );
   let accountVaultPositionUpdate = new AccountVaultPositionUpdate(id);
+  accountVaultPositionUpdate.order = newOrder;
   accountVaultPositionUpdate.account = account.id;
   accountVaultPositionUpdate.accountVaultPosition = accountVaultPositionId;
   accountVaultPositionUpdate.timestamp = transaction.timestamp;
@@ -75,18 +72,24 @@ export function createFirst(
   account: Account,
   vault: Vault,
   vaultPositionId: string,
+  newAccountVaultPositionOrder: BigInt,
   transaction: Transaction,
   depositedTokens: BigInt,
   receivedShares: BigInt,
   balancePosition: BigInt
 ): AccountVaultPositionUpdate {
   log.debug('[VaultPositionUpdate] Create first', []);
-  let id = buildIdFromAccountAndTransaction(account, transaction);
+  let id = buildIdFromAccountVaultAndOrder(
+    account,
+    vault,
+    newAccountVaultPositionOrder
+  );
   let accountVaultPositionFirstUpdate = AccountVaultPositionUpdate.load(id);
-
   if (accountVaultPositionFirstUpdate == null) {
+    // We always should create an update.
     accountVaultPositionFirstUpdate = createAccountVaultPositionUpdate(
       id,
+      newAccountVaultPositionOrder,
       account,
       vault,
       vaultPositionId,
@@ -101,9 +104,40 @@ export function createFirst(
       BIGINT_ZERO,
       balancePosition
     );
+  } else {
+    log.warning(
+      'INVALID Deposit First: update FOUND (shouldnt) UpdateID {} Account {}',
+      [id, account.id]
+    );
   }
 
   return accountVaultPositionFirstUpdate!;
+}
+
+export function getNewOrder(id: string, txHash: string): BigInt {
+  log.info(
+    '[AccountVaultPositionUpdate] Getting new order for id {} (tx: {}).',
+    [id, txHash]
+  );
+  if (id === null) {
+    log.info(
+      '[AccountVaultPositionUpdate] Id is null. New order value is 0 (tx: {}).',
+      [txHash]
+    );
+    return BIGINT_ZERO;
+  }
+  let latestAccountVaultPositionUpdate = AccountVaultPositionUpdate.load(id);
+  let newOrder = BIGINT_ZERO;
+
+  if (latestAccountVaultPositionUpdate !== null) {
+    newOrder = incrementOrder(latestAccountVaultPositionUpdate.order);
+  } else {
+    log.warning(
+      'INVALID Deposit: latestUpdateID NOT found (shouldnt) !== LatestUpdateID {} tx: {}',
+      [id, txHash]
+    );
+  }
+  return newOrder;
 }
 
 export function deposit(
@@ -116,13 +150,25 @@ export function deposit(
   receivedShares: BigInt,
   balancePosition: BigInt
 ): AccountVaultPositionUpdate {
-  log.debug('[VaultPositionUpdate] Deposit', []);
-  let id = buildIdFromAccountAndTransaction(account, transaction);
-  let accountVaultPositionUpdate = AccountVaultPositionUpdate.load(id);
+  log.debug(
+    '[VaultPositionUpdate] Deposit. Creating new account vault position update. Account {} Vault {}',
+    [account.id, vault.id]
+  );
+  let newAccountVaultPositionUpdateOrder = getNewOrder(
+    latestUpdateId,
+    transaction.hash.toHexString()
+  );
 
+  let id = buildIdFromAccountVaultAndOrder(
+    account,
+    vault,
+    newAccountVaultPositionUpdateOrder
+  );
+  let accountVaultPositionUpdate = AccountVaultPositionUpdate.load(id);
   if (accountVaultPositionUpdate == null) {
     accountVaultPositionUpdate = createAccountVaultPositionUpdate(
       id,
+      newAccountVaultPositionUpdateOrder,
       account,
       vault,
       vaultPositionId,
@@ -137,6 +183,11 @@ export function deposit(
       BIGINT_ZERO,
       balancePosition
     );
+  } else {
+    log.warning(
+      'INVALID Deposit: update FOUND (shouldnt) UpdateID {} Account {} TX {}',
+      [id, account.id, transaction.hash.toHexString()]
+    );
   }
 
   return accountVaultPositionUpdate!;
@@ -144,6 +195,7 @@ export function deposit(
 
 export function transfer(
   accountVaultPositionUpdateId: string,
+  newAccountVaultPositionOrder: BigInt,
   createFirstAccountVaultPositionUpdate: boolean,
   accountVaultPosition: AccountVaultPosition,
   account: Account,
@@ -155,8 +207,13 @@ export function transfer(
   transaction: Transaction
 ): void {
   log.info(
-    '[AccountVaultPositionUpdate] Transfer. Processing account {} for vault position {} in TX {}',
-    [account.id, accountVaultPosition.id, transaction.hash.toHexString()]
+    '[AccountVaultPositionUpdate] Transfer. Processing account {} for vault position {} and order {} in TX {}',
+    [
+      account.id,
+      accountVaultPosition.id,
+      newAccountVaultPositionOrder.toString(),
+      transaction.hash.toHexString(),
+    ]
   );
   if (createFirstAccountVaultPositionUpdate) {
     log.info(
@@ -165,6 +222,7 @@ export function transfer(
     );
     createAccountVaultPositionUpdate(
       accountVaultPositionUpdateId,
+      newAccountVaultPositionOrder,
       account,
       vault,
       accountVaultPosition.id,
@@ -188,13 +246,18 @@ export function transfer(
       accountVaultPosition.latestUpdate
     );
     if (latestAccountVaultPositionUpdate !== null) {
-      let id = buildIdFromAccountAndTransaction(account, transaction);
+      let id = buildIdFromAccountVaultAndOrder(
+        account,
+        vault,
+        newAccountVaultPositionOrder
+      );
       log.info(
         '[AccountVaultPositionUpdate] Transfer. Creating account vault position update (id {}) for position id {}',
         [id, accountVaultPosition.id]
       );
       createAccountVaultPositionUpdate(
         id,
+        newAccountVaultPositionOrder,
         account,
         vault,
         accountVaultPosition.id,
@@ -209,6 +272,11 @@ export function transfer(
         receivingTransfer ? tokenAmount : BIGINT_ZERO,
         balancePosition
       );
+    } else {
+      log.warning('INVALID Transfer: update FOUND (shouldnt) {} Account {}', [
+        accountVaultPosition.latestUpdate,
+        account.id,
+      ]);
     }
   }
 }

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -1,4 +1,12 @@
-import { BigInt, ethereum, Bytes, Address } from '@graphprotocol/graph-ts';
+import {
+  BigInt,
+  ethereum,
+  Bytes,
+  Address,
+  log,
+  dataSource,
+} from '@graphprotocol/graph-ts';
+import { Transaction } from '../../generated/schema';
 
 export function getTimeInMillis(time: BigInt): BigInt {
   return time.times(BigInt.fromI32(1000));
@@ -28,6 +36,10 @@ export function buildIdFromEvent(event: ethereum.Event): string {
   return buildId(event.transaction.hash, event.logIndex);
 }
 
+export function buildIdFromTransaction(transaction: Transaction): string {
+  return buildId(transaction.hash, transaction.index);
+}
+
 export function buildBlockId(block: ethereum.Block): string {
   return (
     block.hash.toHex() +
@@ -43,4 +55,40 @@ export function buildUpdateId(address: Address, tx: Bytes, n: BigInt): string {
     .toHexString()
     .concat('-')
     .concat(tx.toHexString().concat('-').concat(n.toString()));
+}
+
+export function printCallInfo(label: string, call: ethereum.Call): void {
+  let blockNumber = call.block.number.toString();
+  let txHash = call.transaction.hash.toHexString();
+  log.info('{} {} block {} call.to {}', [
+    label,
+    txHash,
+    blockNumber,
+    call.to.toHexString(),
+  ]);
+  log.info('{} {} block {} call.from {}', [
+    label,
+    txHash,
+    ,
+    blockNumber,
+    call.from.toHexString(),
+  ]);
+  log.info('{} {} block {} call.transaction.from {}', [
+    label,
+    txHash,
+    blockNumber,
+    call.transaction.from.toHexString(),
+  ]);
+  log.info('{} {} block {} call.transaction.to {}', [
+    label,
+    txHash,
+    blockNumber,
+    call.transaction.to.toHexString(),
+  ]);
+  log.info('{} {} block {} dataSource.address {}', [
+    label,
+    txHash,
+    blockNumber,
+    dataSource.address().toHexString(),
+  ]);
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,3 +7,8 @@ export let BIGINT_ZERO = BigInt.fromI32(0);
 export let BIGINT_ONE = BigInt.fromI32(1);
 export let BIGDECIMAL_ZERO = new BigDecimal(BIGINT_ZERO);
 export let MAX_UINT = BigInt.fromI32(2).times(BigInt.fromI32(255));
+export let DAYS_PER_YEAR = new BigDecimal(BigInt.fromI32(365));
+export let MS_PER_DAY = new BigDecimal(BigInt.fromI32(24 * 60 * 60 * 1000));
+export let MS_PER_YEAR = DAYS_PER_YEAR.times(
+  new BigDecimal(BigInt.fromI32(24 * 60 * 60 * 1000))
+);

--- a/src/utils/registry/registry.ts
+++ b/src/utils/registry/registry.ts
@@ -1,0 +1,27 @@
+import { Address, log } from '@graphprotocol/graph-ts';
+import { Registry, Transaction } from '../../../generated/schema';
+
+export function buildId(address: Address): string {
+  return address.toHexString();
+}
+
+export function getOrCreate(
+  address: Address,
+  transaction: Transaction
+): Registry {
+  let id = buildId(address);
+  log.debug('[Registry] Loading registry for id {}', [id]);
+  let registry = Registry.load(id);
+
+  if (registry == null) {
+    log.info('[Registry] Create registry for address {}', [
+      address.toHexString(),
+    ]);
+    registry = new Registry(id);
+    registry.timestamp = transaction.timestamp;
+    registry.blockNumber = transaction.blockNumber;
+    registry.transaction = transaction.id;
+    registry.save();
+  }
+  return registry as Registry;
+}

--- a/src/utils/strategy/strategy-report-result.ts
+++ b/src/utils/strategy/strategy-report-result.ts
@@ -1,0 +1,73 @@
+import { log } from '@graphprotocol/graph-ts';
+import {
+  StrategyReport,
+  StrategyReportResult,
+  Transaction,
+} from '../../../generated/schema';
+import { buildIdFromTransaction } from '../commons';
+import { BIGDECIMAL_ZERO, DAYS_PER_YEAR, MS_PER_DAY } from '../constants';
+
+export function create(
+  transaction: Transaction,
+  previousReport: StrategyReport,
+  currentReport: StrategyReport
+): StrategyReportResult {
+  log.debug(
+    '[StrategyReportResult] Create strategy report result between previous {} and current report {}. Strategy {}',
+    [previousReport.id, currentReport.id, currentReport.strategy]
+  );
+
+  let id = buildIdFromTransaction(transaction);
+  let strategyReportResult = new StrategyReportResult(id);
+  strategyReportResult.timestamp = transaction.timestamp;
+  strategyReportResult.blockNumber = transaction.blockNumber;
+  strategyReportResult.report = currentReport.id;
+  strategyReportResult.startTimestamp = previousReport.timestamp;
+  strategyReportResult.endTimestamp = currentReport.timestamp;
+  strategyReportResult.duration = currentReport.timestamp
+    .toBigDecimal()
+    .minus(previousReport.timestamp.toBigDecimal());
+  strategyReportResult.durationPr = BIGDECIMAL_ZERO;
+  strategyReportResult.apr = BIGDECIMAL_ZERO;
+  strategyReportResult.transaction = transaction.id;
+
+  let profit = currentReport.totalGain.minus(previousReport.totalGain);
+  let msInDays = strategyReportResult.duration.div(MS_PER_DAY);
+  log.info(
+    '[StrategyReportResult] Report Result - Start / End: {} / {} - Duration: {} (days {}) - Profit: {}',
+    [
+      strategyReportResult.startTimestamp.toString(),
+      strategyReportResult.endTimestamp.toString(),
+      strategyReportResult.duration.toString(),
+      msInDays.toString(),
+      profit.toString(),
+    ]
+  );
+
+  if (
+    !currentReport.totalDebt.isZero() &&
+    !profit.isZero() &&
+    !msInDays.equals(BIGDECIMAL_ZERO)
+  ) {
+    let profitOverTotalDebt = profit
+      .toBigDecimal()
+      .div(currentReport.totalDebt.toBigDecimal());
+    strategyReportResult.durationPr = profitOverTotalDebt;
+    let yearOverDuration = DAYS_PER_YEAR.div(msInDays);
+    let apr = profitOverTotalDebt.times(yearOverDuration);
+
+    log.info(
+      '[StrategyReportResult] Report Result - Duration: {} ms / {} days - Duration (Year): {} - Profit / Total Debt: {} / APR: {}',
+      [
+        strategyReportResult.duration.toString(),
+        msInDays.toString(),
+        yearOverDuration.toString(),
+        profitOverTotalDebt.toString(),
+        apr.toString(),
+      ]
+    );
+    strategyReportResult.apr = apr;
+  }
+  strategyReportResult.save();
+  return strategyReportResult!;
+}

--- a/src/utils/strategy/strategy.ts
+++ b/src/utils/strategy/strategy.ts
@@ -8,9 +8,10 @@ import {
 import { Strategy as StrategyTemplate } from '../../../generated/templates';
 import { Strategy as StrategyContract } from '../../../generated/templates/Vault/Strategy';
 
-import { getTimestampInMillis } from '../commons';
+import { buildIdFromEvent, getTimestampInMillis } from '../commons';
 
 import * as strategyReportLibrary from './strategy-report';
+import * as strategyReportResultLibrary from './strategy-report-result';
 
 export function create(
   transactionId: string,
@@ -55,7 +56,7 @@ export function createReport(
   debtLimit: BigInt,
   event: ethereum.Event
 ): StrategyReport | null {
-  log.debug('[Strategy] Create report', []);
+  log.info('[Strategy] Create report for strategy {}', [strategyId]);
   let strategy = Strategy.load(strategyId);
   if (strategy !== null) {
     let latestReport = StrategyReport.load(strategy.latestReport);
@@ -74,6 +75,17 @@ export function createReport(
     strategy.latestReport = strategyReport.id;
     strategy.save();
 
+    if (latestReport !== null) {
+      log.info(
+        '[Strategy] Create report result (latest {} vs current {}) for strategy {}',
+        [latestReport.id, strategyReport.id, strategyId]
+      );
+      strategyReportResultLibrary.create(
+        transaction,
+        latestReport as StrategyReport,
+        strategyReport
+      );
+    }
     return strategyReport;
   }
   return null;

--- a/src/utils/vault/vault-update.ts
+++ b/src/utils/vault/vault-update.ts
@@ -115,10 +115,10 @@ export function deposit(
       vaultUpdateId,
       vault,
       transaction,
-      latestVaultUpdate.tokensDeposited.plus(depositedAmount),
-      latestVaultUpdate.tokensWithdrawn,
-      latestVaultUpdate.sharesMinted.plus(sharesMinted),
-      latestVaultUpdate.sharesBurnt,
+      depositedAmount,
+      BIGINT_ZERO, // TokensWithdrawn
+      sharesMinted,
+      BIGINT_ZERO, // SharesBurnt,
       pricePerShare,
       latestVaultUpdate.totalFees,
       latestVaultUpdate.managementFees,
@@ -144,10 +144,10 @@ export function withdraw(
     vaultUpdateId,
     vault,
     transaction,
-    latestVaultUpdate.tokensDeposited,
-    latestVaultUpdate.tokensWithdrawn.plus(withdrawnAmount),
-    latestVaultUpdate.sharesMinted,
-    latestVaultUpdate.sharesBurnt.plus(sharesBurnt),
+    BIGINT_ZERO, // TokensDeposited
+    withdrawnAmount,
+    BIGINT_ZERO, // SharesMinted
+    sharesBurnt,
     pricePerShare,
     latestVaultUpdate.totalFees,
     latestVaultUpdate.managementFees,
@@ -156,6 +156,8 @@ export function withdraw(
   );
   vault.sharesSupply = vault.sharesSupply.minus(sharesBurnt);
   vault.balanceTokens = vault.balanceTokens.minus(withdrawnAmount);
+  vault.balanceTokensIdle = vault.balanceTokensIdle.minus(withdrawnAmount);
+
   vault.latestUpdate = newVaultUpdate.id;
   vault.save();
   return newVaultUpdate;
@@ -173,10 +175,10 @@ export function strategyReported(
     vaultUpdateId,
     vault,
     transaction,
-    latestVaultUpdate.tokensDeposited,
-    latestVaultUpdate.tokensWithdrawn,
-    latestVaultUpdate.sharesMinted,
-    latestVaultUpdate.sharesBurnt,
+    BIGINT_ZERO, // TokensDeposited
+    BIGINT_ZERO, // TokensWithdrawn
+    BIGINT_ZERO, // SharesMinted
+    BIGINT_ZERO, // SharesBurnt
     pricePerShare,
     latestVaultUpdate.totalFees,
     latestVaultUpdate.managementFees,

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -39,7 +39,7 @@ dataSources:
     name: RegistryV2
     network: {{network}}
     source:
-      startBlock: {{startBlock}}
+      startBlock: {{startBlockRegistryV2}}
       address: '{{RegistryV2}}'
       abi: Registry
     mapping:


### PR DESCRIPTION
It includes:

- Several fixes for the account vault positions / updates.
- New entities:
  - Registry: As we have two registries, we track each one, and the vaults registered in each one too. The vault also has a derivedFrom 'registry' field.
  - StrategyReportResult: It contains the APRs per strategy in each harvest. It means, when a strategy is reported, the subgraph calculates the APR from the last report vs the current one. It is not processed when the strategy was reported only once.

Subgraph: https://thegraph.com/explorer/subgraph/salazarguille/yearn-vaults-v2-subgraph-mainnet?version=pending