### PR TITLE
feat: add balanceShares to AccountVaultPositionUpdate 

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -1368,6 +1368,15 @@ export class AccountVaultPositionUpdate extends Entity {
     this.set("sharesReceived", Value.fromBigInt(value));
   }
 
+  get balanceShares(): BigInt {
+    let value = this.get("balanceShares");
+    return value.toBigInt();
+  }
+
+  set balanceShares(value: BigInt) {
+    this.set("balanceShares", Value.fromBigInt(value));
+  }
+
   get balancePosition(): BigInt {
     let value = this.get("balancePosition");
     return value.toBigInt();

--- a/schema.graphql
+++ b/schema.graphql
@@ -332,6 +332,8 @@ type AccountVaultPositionUpdate @entity {
   sharesSent: BigInt!
   # "Share tokens received"
   sharesReceived: BigInt!
+  # "The balance of shares"
+  balanceShares: BigInt!
   "The balance position."
   balancePosition: BigInt!
   "Vault Update"

--- a/src/utils/account/vault-position-update.ts
+++ b/src/utils/account/vault-position-update.ts
@@ -38,6 +38,7 @@ export function createAccountVaultPositionUpdate(
   sharesReceived: BigInt,
   tokensSent: BigInt,
   tokensReceived: BigInt,
+  balanceShares: BigInt,
   balancePosition: BigInt
 ): AccountVaultPositionUpdate {
   log.info(
@@ -59,6 +60,7 @@ export function createAccountVaultPositionUpdate(
   accountVaultPositionUpdate.sharesReceived = sharesReceived;
   accountVaultPositionUpdate.tokensSent = tokensSent;
   accountVaultPositionUpdate.tokensReceived = tokensReceived;
+  accountVaultPositionUpdate.balanceShares = balanceShares;
   accountVaultPositionUpdate.balancePosition = balancePosition;
   accountVaultPositionUpdate.vaultUpdate = vaultUpdateLibrary.buildIdFromVaultAndTransaction(
     vault,
@@ -76,6 +78,7 @@ export function createFirst(
   transaction: Transaction,
   depositedTokens: BigInt,
   receivedShares: BigInt,
+  balanceShares: BigInt,
   balancePosition: BigInt
 ): AccountVaultPositionUpdate {
   log.debug('[VaultPositionUpdate] Create first', []);
@@ -102,6 +105,7 @@ export function createFirst(
       BIGINT_ZERO,
       BIGINT_ZERO,
       BIGINT_ZERO,
+      balanceShares,
       balancePosition
     );
   } else {
@@ -148,6 +152,7 @@ export function deposit(
   transaction: Transaction,
   depositedTokens: BigInt,
   receivedShares: BigInt,
+  balanceShares: BigInt,
   balancePosition: BigInt
 ): AccountVaultPositionUpdate {
   log.debug(
@@ -181,6 +186,7 @@ export function deposit(
       BIGINT_ZERO,
       BIGINT_ZERO,
       BIGINT_ZERO,
+      balanceShares,
       balancePosition
     );
   } else {
@@ -203,6 +209,7 @@ export function transfer(
   vault: Vault,
   tokenAmount: BigInt,
   shareAmount: BigInt,
+  balanceShares: BigInt,
   balancePosition: BigInt,
   transaction: Transaction
 ): void {
@@ -235,6 +242,7 @@ export function transfer(
       receivingTransfer ? shareAmount : BIGINT_ZERO,
       receivingTransfer ? BIGINT_ZERO : tokenAmount,
       receivingTransfer ? tokenAmount : BIGINT_ZERO,
+      balanceShares,
       balancePosition
     );
   } else {
@@ -270,6 +278,7 @@ export function transfer(
         receivingTransfer ? shareAmount : BIGINT_ZERO,
         receivingTransfer ? BIGINT_ZERO : tokenAmount,
         receivingTransfer ? tokenAmount : BIGINT_ZERO,
+        balanceShares,
         balancePosition
       );
     } else {

--- a/src/utils/account/vault-position.ts
+++ b/src/utils/account/vault-position.ts
@@ -60,14 +60,13 @@ export function getOrCreate(
 
 export function getBalancePosition(
   account: Account,
-  token: Token,
-  balanceShares: BigInt,
   vaultContract: VaultContract
 ): BigInt {
   log.info('GetBalancePosition account  {} ', [account.id]);
   let pricePerShare = vaultContract.pricePerShare();
   let decimals = vaultContract.decimals();
   // (vault.balanceOf(account) * (vault.pricePerShare() / 10**vault.decimals()))
+  let balanceShares = vaultContract.balanceOf(Address.fromString(account.id));
   let u8Decimals = u8(decimals.toI32());
   let divisor = BigInt.fromI32(10).pow(u8Decimals);
   return balanceShares.times(pricePerShare).div(divisor);
@@ -135,12 +134,7 @@ export function deposit(
   // TODO Use tokenLibrary.getOrCreate
   let token = Token.load(vault.token) as Token;
   let balanceShares = vaultContract.balanceOf(Address.fromString(account.id));
-  let balancePosition = getBalancePosition(
-    account,
-    token,
-    balanceShares,
-    vaultContract
-  );
+  let balancePosition = getBalancePosition(account, vaultContract);
   if (accountVaultPosition == null) {
     log.info('Tx: {} Account vault position {} not found. Creating it.', [
       txHash,
@@ -210,12 +204,7 @@ export function withdraw(
   let vault = Vault.load(accountVaultPosition.vault) as Vault;
   let token = Token.load(vault.token) as Token;
   let balanceShares = vaultContract.balanceOf(Address.fromString(account.id));
-  let balancePosition = getBalancePosition(
-    account,
-    token,
-    balanceShares,
-    vaultContract
-  );
+  let balancePosition = getBalancePosition(account, vaultContract);
   let newAccountVaultPositionOrder = vaultPositionUpdateLibrary.getNewOrder(
     accountVaultPosition.latestUpdate,
     transaction.hash.toHexString()
@@ -319,12 +308,7 @@ export function transferForAccount(
   let accountVaultPositionId = buildId(account, vault);
   let accountVaultPosition = AccountVaultPosition.load(accountVaultPositionId);
   let balanceShares = vaultContract.balanceOf(Address.fromString(account.id));
-  let balancePosition = getBalancePosition(
-    account,
-    token,
-    balanceShares,
-    vaultContract
-  );
+  let balancePosition = getBalancePosition(account, vaultContract);
   let latestUpdateId: string;
   let newAccountVaultPositionOrder: BigInt;
   if (accountVaultPosition == null) {

--- a/src/utils/account/vault-position.ts
+++ b/src/utils/account/vault-position.ts
@@ -61,17 +61,16 @@ export function getOrCreate(
 export function getBalancePosition(
   account: Account,
   token: Token,
+  balanceShares: BigInt,
   vaultContract: VaultContract
 ): BigInt {
   log.info('GetBalancePosition account  {} ', [account.id]);
   let pricePerShare = vaultContract.pricePerShare();
   let decimals = vaultContract.decimals();
-  let accountAddress = Address.fromString(account.id);
-  let accountBalance = vaultContract.balanceOf(accountAddress);
   // (vault.balanceOf(account) * (vault.pricePerShare() / 10**vault.decimals()))
   let u8Decimals = u8(decimals.toI32());
   let divisor = BigInt.fromI32(10).pow(u8Decimals);
-  return accountBalance.times(pricePerShare).div(divisor);
+  return balanceShares.times(pricePerShare).div(divisor);
 }
 
 export class VaultPositionResponse {
@@ -135,7 +134,13 @@ export function deposit(
   let accountVaultPositionUpdate: AccountVaultPositionUpdate;
   // TODO Use tokenLibrary.getOrCreate
   let token = Token.load(vault.token) as Token;
-  let balancePosition = getBalancePosition(account, token, vaultContract);
+  let balanceShares = vaultContract.balanceOf(Address.fromString(account.id));
+  let balancePosition = getBalancePosition(
+    account,
+    token,
+    balanceShares,
+    vaultContract
+  );
   if (accountVaultPosition == null) {
     log.info('Tx: {} Account vault position {} not found. Creating it.', [
       txHash,
@@ -158,6 +163,7 @@ export function deposit(
       transaction,
       depositedTokens,
       receivedShares,
+      balanceShares,
       balancePosition
     );
   } else {
@@ -179,6 +185,7 @@ export function deposit(
       transaction,
       depositedTokens,
       receivedShares,
+      balanceShares,
       balancePosition
     );
   }
@@ -202,7 +209,13 @@ export function withdraw(
   let account = Account.load(accountVaultPosition.account) as Account;
   let vault = Vault.load(accountVaultPosition.vault) as Vault;
   let token = Token.load(vault.token) as Token;
-  let balancePosition = getBalancePosition(account, token, vaultContract);
+  let balanceShares = vaultContract.balanceOf(Address.fromString(account.id));
+  let balancePosition = getBalancePosition(
+    account,
+    token,
+    balanceShares,
+    vaultContract
+  );
   let newAccountVaultPositionOrder = vaultPositionUpdateLibrary.getNewOrder(
     accountVaultPosition.latestUpdate,
     transaction.hash.toHexString()
@@ -227,7 +240,8 @@ export function withdraw(
     BIGINT_ZERO, // sharesSent
     BIGINT_ZERO, // sharesReceived
     BIGINT_ZERO, // tokensSent
-    BIGINT_ZERO, // tokensReceived
+    BIGINT_ZERO, // tokensReceived,
+    balanceShares,
     balancePosition
   );
   accountVaultPosition.balanceShares = accountVaultPosition.balanceShares.minus(
@@ -285,6 +299,7 @@ export function withdrawZero(
     BIGINT_ZERO, // sharesReceived
     BIGINT_ZERO, // tokensSent
     BIGINT_ZERO, // tokensReceived
+    BIGINT_ZERO,
     BIGINT_ZERO
   );
   accountVaultPosition.save();
@@ -303,7 +318,13 @@ export function transferForAccount(
 ): void {
   let accountVaultPositionId = buildId(account, vault);
   let accountVaultPosition = AccountVaultPosition.load(accountVaultPositionId);
-  let balancePosition = getBalancePosition(account, token, vaultContract);
+  let balanceShares = vaultContract.balanceOf(Address.fromString(account.id));
+  let balancePosition = getBalancePosition(
+    account,
+    token,
+    balanceShares,
+    vaultContract
+  );
   let latestUpdateId: string;
   let newAccountVaultPositionOrder: BigInt;
   if (accountVaultPosition == null) {
@@ -361,6 +382,7 @@ export function transferForAccount(
     receivingTransfer ? shareAmount : BIGINT_ZERO,
     receivingTransfer ? BIGINT_ZERO : tokenAmount,
     receivingTransfer ? tokenAmount : BIGINT_ZERO,
+    balanceShares,
     balancePosition
   );
 


### PR DESCRIPTION
This is to be able to calculate historical earnings for a user. Can't use `balancePosition` for this as the `pricePerShare` (from VaultUpdates) of the vault changes over time, whereas `balancePosition` is static at one point in time.