### PR TITLE
Fix strategies without reports (and harvest txs)

### DIFF
--- a/abis/Vault.json
+++ b/abis/Vault.json
@@ -150,6 +150,22 @@
       "name": "StrategyReported",
       "type": "event"
     },
+    {
+      "name": "StrategyReported",
+      "inputs": [
+        { "type": "address", "name": "strategy", "indexed": true },
+        { "type": "uint256", "name": "gain", "indexed": false },
+        { "type": "uint256", "name": "loss", "indexed": false },
+        { "type": "uint256", "name": "debtPaid", "indexed": false },
+        { "type": "uint256", "name": "totalGain", "indexed": false },
+        { "type": "uint256", "name": "totalLoss", "indexed": false },
+        { "type": "uint256", "name": "totalDebt", "indexed": false },
+        { "type": "uint256", "name": "debtAdded", "indexed": false },
+        { "type": "uint256", "name": "debtRatio", "indexed": false }
+      ],
+      "anonymous": false,
+      "type": "event"
+    },
     { "name": "UpdatePerformanceFee", "inputs": [{ "type": "uint256", "name": "performanceFee", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "UpdateManagementFee", "inputs": [{ "type": "uint256", "name": "managementFee", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "StrategyRemovedFromQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },

--- a/generated/CurveSETHVault/Vault.ts
+++ b/generated/CurveSETHVault/Vault.ts
@@ -172,6 +172,56 @@ export class StrategyReported__Params {
   }
 }
 
+export class StrategyReported1 extends ethereum.Event {
+  get params(): StrategyReported1__Params {
+    return new StrategyReported1__Params(this);
+  }
+}
+
+export class StrategyReported1__Params {
+  _event: StrategyReported1;
+
+  constructor(event: StrategyReported1) {
+    this._event = event;
+  }
+
+  get strategy(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get gain(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get loss(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get debtPaid(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get totalGain(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+
+  get totalLoss(): BigInt {
+    return this._event.parameters[5].value.toBigInt();
+  }
+
+  get totalDebt(): BigInt {
+    return this._event.parameters[6].value.toBigInt();
+  }
+
+  get debtAdded(): BigInt {
+    return this._event.parameters[7].value.toBigInt();
+  }
+
+  get debtRatio(): BigInt {
+    return this._event.parameters[8].value.toBigInt();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/generated/Registry/Vault.ts
+++ b/generated/Registry/Vault.ts
@@ -172,6 +172,56 @@ export class StrategyReported__Params {
   }
 }
 
+export class StrategyReported1 extends ethereum.Event {
+  get params(): StrategyReported1__Params {
+    return new StrategyReported1__Params(this);
+  }
+}
+
+export class StrategyReported1__Params {
+  _event: StrategyReported1;
+
+  constructor(event: StrategyReported1) {
+    this._event = event;
+  }
+
+  get strategy(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get gain(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get loss(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get debtPaid(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get totalGain(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+
+  get totalLoss(): BigInt {
+    return this._event.parameters[5].value.toBigInt();
+  }
+
+  get totalDebt(): BigInt {
+    return this._event.parameters[6].value.toBigInt();
+  }
+
+  get debtAdded(): BigInt {
+    return this._event.parameters[7].value.toBigInt();
+  }
+
+  get debtRatio(): BigInt {
+    return this._event.parameters[8].value.toBigInt();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/generated/RegistryV2/Vault.ts
+++ b/generated/RegistryV2/Vault.ts
@@ -172,6 +172,56 @@ export class StrategyReported__Params {
   }
 }
 
+export class StrategyReported1 extends ethereum.Event {
+  get params(): StrategyReported1__Params {
+    return new StrategyReported1__Params(this);
+  }
+}
+
+export class StrategyReported1__Params {
+  _event: StrategyReported1;
+
+  constructor(event: StrategyReported1) {
+    this._event = event;
+  }
+
+  get strategy(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get gain(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get loss(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get debtPaid(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get totalGain(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+
+  get totalLoss(): BigInt {
+    return this._event.parameters[5].value.toBigInt();
+  }
+
+  get totalDebt(): BigInt {
+    return this._event.parameters[6].value.toBigInt();
+  }
+
+  get debtAdded(): BigInt {
+    return this._event.parameters[7].value.toBigInt();
+  }
+
+  get debtRatio(): BigInt {
+    return this._event.parameters[8].value.toBigInt();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -1743,6 +1743,15 @@ export class StrategyReport extends Entity {
     this.set("debtLimit", Value.fromBigInt(value));
   }
 
+  get debtPaid(): BigInt {
+    let value = this.get("debtPaid");
+    return value.toBigInt();
+  }
+
+  set debtPaid(value: BigInt) {
+    this.set("debtPaid", Value.fromBigInt(value));
+  }
+
   get results(): Array<string> {
     let value = this.get("results");
     return value.toStringArray();

--- a/generated/templates/Strategy/Vault.ts
+++ b/generated/templates/Strategy/Vault.ts
@@ -172,6 +172,56 @@ export class StrategyReported__Params {
   }
 }
 
+export class StrategyReported1 extends ethereum.Event {
+  get params(): StrategyReported1__Params {
+    return new StrategyReported1__Params(this);
+  }
+}
+
+export class StrategyReported1__Params {
+  _event: StrategyReported1;
+
+  constructor(event: StrategyReported1) {
+    this._event = event;
+  }
+
+  get strategy(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get gain(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get loss(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get debtPaid(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get totalGain(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+
+  get totalLoss(): BigInt {
+    return this._event.parameters[5].value.toBigInt();
+  }
+
+  get totalDebt(): BigInt {
+    return this._event.parameters[6].value.toBigInt();
+  }
+
+  get debtAdded(): BigInt {
+    return this._event.parameters[7].value.toBigInt();
+  }
+
+  get debtRatio(): BigInt {
+    return this._event.parameters[8].value.toBigInt();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/generated/templates/Vault/Vault.ts
+++ b/generated/templates/Vault/Vault.ts
@@ -172,6 +172,56 @@ export class StrategyReported__Params {
   }
 }
 
+export class StrategyReported1 extends ethereum.Event {
+  get params(): StrategyReported1__Params {
+    return new StrategyReported1__Params(this);
+  }
+}
+
+export class StrategyReported1__Params {
+  _event: StrategyReported1;
+
+  constructor(event: StrategyReported1) {
+    this._event = event;
+  }
+
+  get strategy(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get gain(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get loss(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get debtPaid(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get totalGain(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+
+  get totalLoss(): BigInt {
+    return this._event.parameters[5].value.toBigInt();
+  }
+
+  get totalDebt(): BigInt {
+    return this._event.parameters[6].value.toBigInt();
+  }
+
+  get debtAdded(): BigInt {
+    return this._event.parameters[7].value.toBigInt();
+  }
+
+  get debtRatio(): BigInt {
+    return this._event.parameters[8].value.toBigInt();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/schema.graphql
+++ b/schema.graphql
@@ -413,6 +413,8 @@ type StrategyReport @entity {
   debtAdded: BigInt!
   "The reported debt limit amount for the strategy."
   debtLimit: BigInt!
+  "The reported debt paid for the strategy. This field is 0 for v0.3.0 or v0.3.1."
+  debtPaid: BigInt!
   # "Vault state"
   # vaultUpdate: VaultUpdate!
   "The results created by this report. They are generated comparing the previous report and the current one."
@@ -485,8 +487,8 @@ type VaultDayData @entity {
   totalReturnsGenerated: BigInt!
   "The total earnings generated in USDC for this vault up to and including this day"
   totalReturnsGeneratedUSDC: BigInt!
-  "The earnings genereated for this vault this day"
+  "The earnings generated for this vault this day"
   dayReturnsGenerated: BigInt!
-  "The earnings genereated in USDC for this vault this day"
+  "The earnings generated in USDC for this vault this day"
   dayReturnsGeneratedUSDC: BigInt!
 }

--- a/src/mappings/strategyMappings.ts
+++ b/src/mappings/strategyMappings.ts
@@ -4,11 +4,16 @@ import * as strategyLibrary from '../utils/strategy/strategy';
 import { getOrCreateTransactionFromEvent } from '../utils/transaction';
 
 export function handleHarvested(event: HarvestedEvent): void {
-  log.debug('[Strategy Mapping] Handle harvested', []);
+  let contractAddress = event.address;
+  let txHash = event.transaction.hash.toHexString();
+  log.info(
+    '[Strategy Mapping] Handle harvested in strategy {} and TX hash {}',
+    [contractAddress.toHexString(), txHash]
+  );
   let ethTransaction = getOrCreateTransactionFromEvent(event, 'Harvested');
   strategyLibrary.harvest(
     event.transaction.from,
-    event.address,
+    contractAddress,
     event.block.timestamp,
     event.block.number,
     event.transaction.hash,

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -1,6 +1,7 @@
 import { log } from '@graphprotocol/graph-ts';
 import {
-  StrategyReported as StrategyReportedEvent,
+  StrategyReported as StrategyReported_v0_3_0_v0_3_1_Event,
+  StrategyReported1 as StrategyReported_v0_3_2_Event,
   Deposit1Call as DepositCall,
   Transfer as TransferEvent,
   Withdraw1Call as WithdrawCall,
@@ -84,8 +85,10 @@ export function handleAddStrategy(call: AddStrategyV1Call): void {
   );
 }
 
-export function handleStrategyReported(event: StrategyReportedEvent): void {
-  log.debug('[Vault mappings] Handle strategy reported', []);
+export function handleStrategyReported_v0_3_0_v0_3_1(
+  event: StrategyReported_v0_3_0_v0_3_1_Event
+): void {
+  log.info('[Vault mappings v0_3_0 and v0_3_1] Handle strategy reported', []);
   let ethTransaction = getOrCreateTransactionFromEvent(
     event,
     'StrategyReportedEvent'
@@ -100,6 +103,44 @@ export function handleStrategyReported(event: StrategyReportedEvent): void {
     event.params.totalDebt,
     event.params.debtAdded,
     event.params.debtLimit,
+    BIGINT_ZERO,
+    event
+  );
+
+  log.info(
+    '[Vault mappings] Updating price per share (strategy reported): {}',
+    [event.transaction.hash.toHexString()]
+  );
+  let vaultContractAddress = event.address;
+  let vaultContract = VaultContract.bind(vaultContractAddress);
+  vaultLibrary.strategyReported(
+    ethTransaction,
+    vaultContract,
+    vaultContractAddress,
+    vaultContract.pricePerShare()
+  );
+}
+
+export function handleStrategyReported_v0_3_2(
+  event: StrategyReported_v0_3_2_Event
+): void {
+  log.info('[Vault mappings v0_3_2] Handle strategy reported', []);
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'StrategyReportedEvent'
+  );
+
+  strategyLibrary.createReport(
+    ethTransaction,
+    event.params.strategy.toHexString(),
+    event.params.gain,
+    event.params.loss,
+    event.params.totalGain,
+    event.params.totalLoss,
+    event.params.totalDebt,
+    event.params.debtAdded,
+    event.params.debtRatio,
+    event.params.debtPaid,
     event
   );
 

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -85,6 +85,11 @@ export function handleAddStrategy(call: AddStrategyV1Call): void {
   );
 }
 
+/**
+ * We have two handlers to process the StrategyReported event due to incompatibility in both event structure.
+ * This is for vault versions 0.3.0 and 0.3.1.
+ * If you need 0.3.2 or superior, please see the 'handleStrategyReported' handler.
+ */
 export function handleStrategyReported_v0_3_0_v0_3_1(
   event: StrategyReported_v0_3_0_v0_3_1_Event
 ): void {
@@ -121,7 +126,16 @@ export function handleStrategyReported_v0_3_0_v0_3_1(
   );
 }
 
-export function handleStrategyReported_v0_3_2(
+/**
+ * We have two handlers to process the StrategyReported event due to incompatibility in both event structure.
+ * This is for vault versions 0.3.2 or superior.
+ *
+ * This version includes the new field `debtPaid` introduced in the Vault version 0.3.2.
+ *
+ * In case a new structure is implemented, please create a new handler.
+ * If you need 0.3.0 or 0.3.1, please see the 'handleStrategyReported_v0_3_0_v0_3_1' handler.
+ */
+export function handleStrategyReported(
   event: StrategyReported_v0_3_2_Event
 ): void {
   log.info('[Vault mappings v0_3_2] Handle strategy reported', []);

--- a/src/utils/strategy/strategy-report.ts
+++ b/src/utils/strategy/strategy-report.ts
@@ -13,9 +13,10 @@ export function getOrCreate(
   totalDebt: BigInt,
   debtAdded: BigInt,
   debtLimit: BigInt,
+  debtPaid: BigInt,
   event: ethereum.Event
 ): StrategyReport {
-  log.debug('[StrategyReport] Get or create strategy report', []);
+  log.info('[StrategyReport] Get or create strategy report', []);
 
   let strategyReportId = buildIdFromEvent(event);
   let strategyReport = StrategyReport.load(strategyReportId);
@@ -32,6 +33,7 @@ export function getOrCreate(
     strategyReport.totalDebt = totalDebt;
     strategyReport.debtAdded = debtAdded;
     strategyReport.debtLimit = debtLimit;
+    strategyReport.debtPaid = debtPaid;
     strategyReport.save();
   }
   return strategyReport!;

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -142,7 +142,9 @@ templates:
           file: ./abis/Oracle.json
       eventHandlers:
         - event: StrategyReported(indexed address,uint256,uint256,uint256,uint256,uint256,uint256,uint256)
-          handler: handleStrategyReported
+          handler: handleStrategyReported_v0_3_0_v0_3_1
+        - event: StrategyReported(indexed address,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)
+          handler: handleStrategyReported_v0_3_2
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
         - event: UpdatePerformanceFee(uint256)

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -144,7 +144,7 @@ templates:
         - event: StrategyReported(indexed address,uint256,uint256,uint256,uint256,uint256,uint256,uint256)
           handler: handleStrategyReported_v0_3_0_v0_3_1
         - event: StrategyReported(indexed address,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)
-          handler: handleStrategyReported_v0_3_2
+          handler: handleStrategyReported
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
         - event: UpdatePerformanceFee(uint256)


### PR DESCRIPTION
It includes:

- Fix to store reports in the harvest TXs.

Subgraph syncing in this link:  https://thegraph.com/explorer/subgraph/salazarguille/yearn-vaults-v2-subgraph-mainnet

![image](https://user-images.githubusercontent.com/5948309/120556128-522d5200-c3b9-11eb-9241-2c3d88ae2952.png)
