### PR TITLE
feat: add price per token to vault day data [WEB-338]

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -2117,6 +2117,15 @@ export class VaultDayData extends Entity {
   set dayReturnsGeneratedUSDC(value: BigInt) {
     this.set("dayReturnsGeneratedUSDC", Value.fromBigInt(value));
   }
+
+  get tokenPriceUSDC(): BigInt {
+    let value = this.get("tokenPriceUSDC");
+    return value.toBigInt();
+  }
+
+  set tokenPriceUSDC(value: BigInt) {
+    this.set("tokenPriceUSDC", Value.fromBigInt(value));
+  }
 }
 
 export class Yearn extends Entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -494,6 +494,8 @@ type VaultDayData @entity {
   dayReturnsGenerated: BigInt!
   "The earnings generated in USDC for this vault this day"
   dayReturnsGeneratedUSDC: BigInt!
+  "The price of one of the vault's underlying token"
+  tokenPriceUSDC: BigInt!
 }
 
 type Yearn @entity {

--- a/src/utils/account/vault-position.ts
+++ b/src/utils/account/vault-position.ts
@@ -67,6 +67,7 @@ export function getBalancePosition(
   let decimals = vaultContract.decimals();
   // (vault.balanceOf(account) * (vault.pricePerShare() / 10**vault.decimals()))
   let balanceShares = vaultContract.balanceOf(Address.fromString(account.id));
+  // @ts-ignore
   let u8Decimals = u8(decimals.toI32());
   let divisor = BigInt.fromI32(10).pow(u8Decimals);
   return balanceShares.times(pricePerShare).div(divisor);

--- a/src/utils/oracle/usdc-oracle.ts
+++ b/src/utils/oracle/usdc-oracle.ts
@@ -15,3 +15,17 @@ export function usdcPrice(tokenAddress: Address, tokenAmount: BigInt): BigInt {
 
   return tokenAmountUsdc;
 }
+
+export function usdcPricePerToken(tokenAddress: Address): BigInt {
+  let tokenAmountUsdc: BigInt = BIGINT_ZERO;
+
+  let oracle = OracleContract.bind(Address.fromString(USDC_ORACLE_ADDRESS));
+  if (oracle !== null) {
+    let result = oracle.try_getPriceUsdcRecommended(tokenAddress);
+    if (result.reverted === false) {
+      tokenAmountUsdc = result.value;
+    }
+  }
+
+  return tokenAmountUsdc;
+}

--- a/src/utils/vault/vault-day-data.ts
+++ b/src/utils/vault/vault-day-data.ts
@@ -1,7 +1,7 @@
 import { Vault, VaultDayData } from '../../../generated/schema';
 import { Address, BigInt } from '@graphprotocol/graph-ts';
 import { BIGINT_ZERO } from '../constants';
-import { usdcPrice } from '../oracle/usdc-oracle';
+import { usdcPricePerToken } from '../oracle/usdc-oracle';
 import { getTimeInMillis } from '../commons';
 
 export function updateVaultDayData(
@@ -11,14 +11,12 @@ export function updateVaultDayData(
   pricePerShare: BigInt,
   deposited: BigInt,
   withdrawn: BigInt,
-  returnsGenerated: BigInt
+  returnsGenerated: BigInt,
+  decimals: BigInt
 ): void {
   let timestampNum = timestamp.toI32();
   let dayID = timestampNum / 86400;
-  let vaultDayID = vault.id
-    .toString()
-    .concat('-')
-    .concat(BigInt.fromI32(dayID).toString());
+  let vaultDayID = getDayID(vault.id, dayID);
 
   let vaultDayData = VaultDayData.load(vaultDayID);
   if (vaultDayData === null) {
@@ -34,32 +32,41 @@ export function updateVaultDayData(
     vaultDayData.dayReturnsGeneratedUSDC = BIGINT_ZERO;
   }
 
+  let usdcPrice = usdcPricePerToken(tokenAddress);
+
   vaultDayData.pricePerShare = pricePerShare;
   vaultDayData.deposited = vaultDayData.deposited.plus(deposited);
   vaultDayData.withdrawn = vaultDayData.withdrawn.plus(withdrawn);
   vaultDayData.dayReturnsGenerated = returnsGenerated;
-  vaultDayData.dayReturnsGeneratedUSDC = usdcPrice(
-    tokenAddress,
-    returnsGenerated
-  );
+  vaultDayData.tokenPriceUSDC = usdcPrice;
 
-  let previousDayID = vault.id
-    .toString()
-    .concat('-')
-    .concat(BigInt.fromI32(dayID - 1).toString());
+  // @ts-ignore
+  let u8Decimals = u8(decimals.toI32());
+  let priceDivisor = BigInt.fromI32(10).pow(u8Decimals);
 
-  let previousVaultDayData = VaultDayData.load(previousDayID);
-  if (previousVaultDayData === null) {
-    vaultDayData.totalReturnsGenerated = BIGINT_ZERO;
-  } else {
+  vaultDayData.dayReturnsGeneratedUSDC = returnsGenerated
+    .times(usdcPrice)
+    .div(priceDivisor);
+
+  let previousVaultDayData = VaultDayData.load(getDayID(vault.id, dayID - 1));
+  if (previousVaultDayData !== null) {
     vaultDayData.totalReturnsGenerated = previousVaultDayData.totalReturnsGenerated.plus(
       returnsGenerated
     );
-    vaultDayData.totalReturnsGeneratedUSDC = usdcPrice(
-      tokenAddress,
-      vaultDayData.totalReturnsGenerated
-    );
+    vaultDayData.totalReturnsGeneratedUSDC = vaultDayData.totalReturnsGenerated
+      .times(usdcPrice)
+      .div(priceDivisor);
   }
 
   vaultDayData.save();
+}
+
+function getDayID(vaultID: string, dayID: number): string {
+  return (
+    vaultID
+      .toString()
+      .concat('-')
+      // @ts-ignore
+      .concat(BigInt.fromI32(i32(dayID)).toString())
+  );
 }

--- a/src/utils/vault/vault.ts
+++ b/src/utils/vault/vault.ts
@@ -209,7 +209,8 @@ export function deposit(
     pricePerShare,
     depositedAmount,
     BIGINT_ZERO,
-    vaultUpdate.returnsGenerated
+    vaultUpdate.returnsGenerated,
+    vaultContract.decimals()
   );
 
   vault.latestUpdate = vaultUpdate.id;
@@ -341,7 +342,8 @@ export function withdraw(
       pricePerShare,
       BIGINT_ZERO,
       withdrawnAmount,
-      latestVaultUpdate.returnsGenerated
+      latestVaultUpdate.returnsGenerated,
+      vaultContract.decimals()
     );
   }
 }
@@ -549,6 +551,7 @@ export function handleUpdateRewards(
 function getBalancePosition(vaultContract: VaultContract): BigInt {
   let totalAssets = vaultContract.totalAssets();
   let pricePerShare = vaultContract.pricePerShare();
+  // @ts-ignore
   let decimals = u8(vaultContract.decimals().toI32());
   return totalAssets.times(pricePerShare).div(BigInt.fromI32(10).pow(decimals));
 }


### PR DESCRIPTION
This will let us calculate the user earnings from the sdk without having to query historical data from the oracle, since we can derive it from `tokenPriceUSDC` on the `VaultDayData` entity. 

Also it'll speed up deployment because instead of reading from the oracle twice in `VaultDayData`, we only do it once now. 

Fixes https://github.com/yearn/yearn-vaults-v2-subgraph/issues/84