### PR TITLE
fix: updated to use latest oracle. Added handler for StrategyMigrated event [WEB-211]

### DIFF
--- a/abis/Oracle.json
+++ b/abis/Oracle.json
@@ -77,13 +77,7 @@
     },
     { "inputs": [], "name": "managementList", "outputs": [{ "internalType": "contract ManagementList", "name": "", "type": "address" }], "stateMutability": "view", "type": "function" },
     { "inputs": [{ "internalType": "address", "name": "tokenAddress", "type": "address" }], "name": "removeTokenAlias", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
-    {
-      "inputs": [{ "internalType": "address[]", "name": "calculationAddresses", "type": "address[]" }],
-      "name": "setCalculations",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
+    { "inputs": [{ "internalType": "address[]", "name": "calculationAddresses", "type": "address[]" }], "name": "setCalculations", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
     {
       "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
       "name": "tokenAliases",

--- a/abis/Vault.json
+++ b/abis/Vault.json
@@ -166,6 +166,15 @@
       "anonymous": false,
       "type": "event"
     },
+    {
+      "name": "StrategyMigrated",
+      "inputs": [
+        { "type": "address", "name": "oldVersion", "indexed": true },
+        { "type": "address", "name": "newVersion", "indexed": true }
+      ],
+      "anonymous": false,
+      "type": "event"
+    },
     { "name": "UpdatePerformanceFee", "inputs": [{ "type": "uint256", "name": "performanceFee", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "UpdateManagementFee", "inputs": [{ "type": "uint256", "name": "managementFee", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "StrategyRemovedFromQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },

--- a/generated/CurveSETHVault/Vault.ts
+++ b/generated/CurveSETHVault/Vault.ts
@@ -222,6 +222,28 @@ export class StrategyReported1__Params {
   }
 }
 
+export class StrategyMigrated extends ethereum.Event {
+  get params(): StrategyMigrated__Params {
+    return new StrategyMigrated__Params(this);
+  }
+}
+
+export class StrategyMigrated__Params {
+  _event: StrategyMigrated;
+
+  constructor(event: StrategyMigrated) {
+    this._event = event;
+  }
+
+  get oldVersion(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get newVersion(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/generated/Registry/Vault.ts
+++ b/generated/Registry/Vault.ts
@@ -222,6 +222,28 @@ export class StrategyReported1__Params {
   }
 }
 
+export class StrategyMigrated extends ethereum.Event {
+  get params(): StrategyMigrated__Params {
+    return new StrategyMigrated__Params(this);
+  }
+}
+
+export class StrategyMigrated__Params {
+  _event: StrategyMigrated;
+
+  constructor(event: StrategyMigrated) {
+    this._event = event;
+  }
+
+  get oldVersion(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get newVersion(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/generated/RegistryV2/Vault.ts
+++ b/generated/RegistryV2/Vault.ts
@@ -222,6 +222,28 @@ export class StrategyReported1__Params {
   }
 }
 
+export class StrategyMigrated extends ethereum.Event {
+  get params(): StrategyMigrated__Params {
+    return new StrategyMigrated__Params(this);
+  }
+}
+
+export class StrategyMigrated__Params {
+  _event: StrategyMigrated;
+
+  constructor(event: StrategyMigrated) {
+    this._event = event;
+  }
+
+  get oldVersion(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get newVersion(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/generated/templates/Strategy/Vault.ts
+++ b/generated/templates/Strategy/Vault.ts
@@ -222,6 +222,28 @@ export class StrategyReported1__Params {
   }
 }
 
+export class StrategyMigrated extends ethereum.Event {
+  get params(): StrategyMigrated__Params {
+    return new StrategyMigrated__Params(this);
+  }
+}
+
+export class StrategyMigrated__Params {
+  _event: StrategyMigrated;
+
+  constructor(event: StrategyMigrated) {
+    this._event = event;
+  }
+
+  get oldVersion(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get newVersion(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/generated/templates/Vault/Vault.ts
+++ b/generated/templates/Vault/Vault.ts
@@ -222,6 +222,28 @@ export class StrategyReported1__Params {
   }
 }
 
+export class StrategyMigrated extends ethereum.Event {
+  get params(): StrategyMigrated__Params {
+    return new StrategyMigrated__Params(this);
+  }
+}
+
+export class StrategyMigrated__Params {
+  _event: StrategyMigrated;
+
+  constructor(event: StrategyMigrated) {
+    this._event = event;
+  }
+
+  get oldVersion(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get newVersion(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+}
+
 export class UpdatePerformanceFee extends ethereum.Event {
   get params(): UpdatePerformanceFee__Params {
     return new UpdatePerformanceFee__Params(this);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:mainnet": "yarn prepare:mainnet && graph build",
     "thegraph:deploy:kovan": "yarn build:kovan && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ salazarguille/yearn-vaults-v2-subgraph-kovan",
     "thegraph:deploy:rinkeby": "yarn build:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ salazarguille/yearn-vaults-v2-subgraph-rinkeby",
-    "thegraph:deploy:mainnet": "yarn build:mainnet && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ salazarguille/yearn-vaults-v2-subgraph-mainnet",
+    "thegraph:deploy:mainnet": "yarn build:mainnet && graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ jstashh/yearn-crypto-fees",
     "create-local": "graph create --node http://127.0.0.1:8020/ yearn-vaults-v2/subgraph",
     "remove-local": "graph remove --node http://127.0.0.1:8020/ yearn-vaults-v2/subgraph",
     "deploy-local": "yarn build:mainnet && graph deploy --node http://127.0.0.1:8020/ --ipfs http://localhost:5001 yearn-vaults-v2/subgraph",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,7 +2,7 @@ import { BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const GOVERNANCE_ADDRESS = '0xba37b002abafdd8e89a1995da52740bbc013d992';
-export const USDC_ORACLE_ADDRESS = '0xd3ca98D986Be88b72Ff95fc2eC976a5E6339150d';
+export const USDC_ORACLE_ADDRESS = '0x83d95e0d5f402511db06817aff3f9ea88224b030';
 export const DEFAULT_DECIMALS = 18;
 export let BIGINT_ZERO = BigInt.fromI32(0);
 export let BIGINT_ONE = BigInt.fromI32(1);

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -145,6 +145,8 @@ templates:
           handler: handleStrategyReported_v0_3_0_v0_3_1
         - event: StrategyReported(indexed address,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)
           handler: handleStrategyReported
+        - event: StrategyMigrated(indexed address,indexed address)
+          handler: handleStrategyMigrated
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
         - event: UpdatePerformanceFee(uint256)


### PR DESCRIPTION
Subgraph wasn't picking up some strategy addresses, e.g. 
0x979843b8eea56e0bea971445200e0ec3398cdb87
0xf088ac5ebf8423b894903312aac8ac42c3ab3a02
0xdd498eb680b0ce6cac17f7dab0c35beb6e481a6d

This was because we were only listening to when strategies were added to a vault directly. Not when new strategies had been created after a migration. 

Also updated to use new oracle