### PR TITLE
fix: group fees at a token level rather than at a protocol level [WEB-214]

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -207,18 +207,9 @@ export class Token extends Entity {
   set symbol(value: string) {
     this.set("symbol", Value.fromString(value));
   }
-
-  get fees(): string {
-    let value = this.get("fees");
-    return value.toString();
-  }
-
-  set fees(value: string) {
-    this.set("fees", Value.fromString(value));
-  }
 }
 
-export class TokenFees extends Entity {
+export class TokenFee extends Entity {
   constructor(id: string) {
     super();
     this.set("id", Value.fromString(id));
@@ -226,17 +217,17 @@ export class TokenFees extends Entity {
 
   save(): void {
     let id = this.get("id");
-    assert(id !== null, "Cannot save TokenFees entity without an ID");
+    assert(id !== null, "Cannot save TokenFee entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
-      "Cannot save TokenFees entity with non-string ID. " +
+      "Cannot save TokenFee entity with non-string ID. " +
         'Considering using .toHex() to convert the "id" to a string.'
     );
-    store.set("TokenFees", id.toString(), this);
+    store.set("TokenFee", id.toString(), this);
   }
 
-  static load(id: string): TokenFees | null {
-    return store.get("TokenFees", id) as TokenFees | null;
+  static load(id: string): TokenFee | null {
+    return store.get("TokenFee", id) as TokenFee | null;
   }
 
   get id(): string {

--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -208,6 +208,46 @@ export class Token extends Entity {
     this.set("symbol", Value.fromString(value));
   }
 
+  get fees(): string {
+    let value = this.get("fees");
+    return value.toString();
+  }
+
+  set fees(value: string) {
+    this.set("fees", Value.fromString(value));
+  }
+}
+
+export class TokenFees extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id !== null, "Cannot save TokenFees entity without an ID");
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save TokenFees entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("TokenFees", id.toString(), this);
+  }
+
+  static load(id: string): TokenFees | null {
+    return store.get("TokenFees", id) as TokenFees | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
   get treasuryFees(): BigInt {
     let value = this.get("treasuryFees");
     return value.toBigInt();
@@ -233,6 +273,15 @@ export class Token extends Entity {
 
   set totalFees(value: BigInt) {
     this.set("totalFees", Value.fromBigInt(value));
+  }
+
+  get token(): string {
+    let value = this.get("token");
+    return value.toString();
+  }
+
+  set token(value: string) {
+    this.set("token", Value.fromString(value));
   }
 }
 

--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -207,6 +207,33 @@ export class Token extends Entity {
   set symbol(value: string) {
     this.set("symbol", Value.fromString(value));
   }
+
+  get treasuryFees(): BigInt {
+    let value = this.get("treasuryFees");
+    return value.toBigInt();
+  }
+
+  set treasuryFees(value: BigInt) {
+    this.set("treasuryFees", Value.fromBigInt(value));
+  }
+
+  get strategyFees(): BigInt {
+    let value = this.get("strategyFees");
+    return value.toBigInt();
+  }
+
+  set strategyFees(value: BigInt) {
+    this.set("strategyFees", Value.fromBigInt(value));
+  }
+
+  get totalFees(): BigInt {
+    let value = this.get("totalFees");
+    return value.toBigInt();
+  }
+
+  set totalFees(value: BigInt) {
+    this.set("totalFees", Value.fromBigInt(value));
+  }
 }
 
 export class Registry extends Entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -44,12 +44,19 @@ type Token @entity {
   name: String!
   "Symbol of the Token"
   symbol: String!
+  fees: TokenFees!
+}
+
+type TokenFees @entity {
+  "Token address"
+  id: ID!
   "Fees paid using this token to the treasury"
   treasuryFees: BigInt!
   "Fees paid using this token to strategies"
   strategyFees: BigInt!
   "Fees paid using this token to strategies and the treasury"
   totalFees: BigInt!
+  token: Token! @derivedFrom(field: "fees")
 }
 
 enum VaultClassification {

--- a/schema.graphql
+++ b/schema.graphql
@@ -44,6 +44,12 @@ type Token @entity {
   name: String!
   "Symbol of the Token"
   symbol: String!
+  "Fees paid using this token to the treasury"
+  treasuryFees: BigInt!
+  "Fees paid using this token to strategies"
+  strategyFees: BigInt!
+  "Fees paid using this token to strategies and the treasury"
+  totalFees: BigInt!
 }
 
 enum VaultClassification {

--- a/schema.graphql
+++ b/schema.graphql
@@ -44,10 +44,9 @@ type Token @entity {
   name: String!
   "Symbol of the Token"
   symbol: String!
-  fees: TokenFees!
 }
 
-type TokenFees @entity {
+type TokenFee @entity {
   "Token address"
   id: ID!
   "Fees paid using this token to the treasury"
@@ -56,7 +55,7 @@ type TokenFees @entity {
   strategyFees: BigInt!
   "Fees paid using this token to strategies and the treasury"
   totalFees: BigInt!
-  token: Token! @derivedFrom(field: "fees")
+  token: Token!
 }
 
 enum VaultClassification {

--- a/src/utils/token-fees.ts
+++ b/src/utils/token-fees.ts
@@ -1,0 +1,40 @@
+import { Token, TokenFees } from '../../generated/schema';
+import { BigInt, log } from '@graphprotocol/graph-ts';
+import { BIGINT_ZERO } from './constants';
+
+export function create(tokenId: string): TokenFees {
+  let fees = new TokenFees(tokenId);
+  fees.strategyFees = BIGINT_ZERO;
+  fees.treasuryFees = BIGINT_ZERO;
+  fees.totalFees = BIGINT_ZERO;
+  fees.save();
+  return fees;
+}
+
+export function addStrategyFee(tokenId: string, amount: BigInt): void {
+  let fees = TokenFees.load(tokenId);
+  if (fees !== null) {
+    fees.strategyFees = fees.strategyFees.plus(amount);
+    fees.totalFees = fees.totalFees.plus(amount);
+    fees.save();
+  } else {
+    log.warning(
+      'trying to add adding strategy fees for token {} but it has not been created',
+      [tokenId]
+    );
+  }
+}
+
+export function addTreasuryFee(tokenId: string, amount: BigInt): void {
+  let fees = TokenFees.load(tokenId);
+  if (fees !== null) {
+    fees.treasuryFees = fees.treasuryFees.plus(amount);
+    fees.totalFees = fees.totalFees.plus(amount);
+    fees.save();
+  } else {
+    log.warning(
+      'trying to add adding treasury fees for token {} but it has not been created',
+      [tokenId]
+    );
+  }
+}

--- a/src/utils/token-fees.ts
+++ b/src/utils/token-fees.ts
@@ -2,7 +2,27 @@ import { TokenFee } from '../../generated/schema';
 import { BigInt, log } from '@graphprotocol/graph-ts';
 import { BIGINT_ZERO } from './constants';
 
-export function create(tokenId: string): TokenFee {
+export function addStrategyFee(tokenId: string, amount: BigInt): void {
+  let fee = TokenFee.load(tokenId);
+  if (fee === null) {
+    fee = create(tokenId);
+  }
+  fee.strategyFees = fee.strategyFees.plus(amount);
+  fee.totalFees = fee.totalFees.plus(amount);
+  fee.save();
+}
+
+export function addTreasuryFee(tokenId: string, amount: BigInt): void {
+  let fee = TokenFee.load(tokenId);
+  if (fee === null) {
+    fee = create(tokenId);
+  }
+  fee.treasuryFees = fee.treasuryFees.plus(amount);
+  fee.totalFees = fee.totalFees.plus(amount);
+  fee.save();
+}
+
+function create(tokenId: string): TokenFee {
   let fees = new TokenFee(tokenId);
   fees.strategyFees = BIGINT_ZERO;
   fees.treasuryFees = BIGINT_ZERO;
@@ -10,32 +30,4 @@ export function create(tokenId: string): TokenFee {
   fees.token = tokenId;
   fees.save();
   return fees;
-}
-
-export function addStrategyFee(tokenId: string, amount: BigInt): void {
-  let fee = TokenFee.load(tokenId);
-  if (fee !== null) {
-    fee.strategyFees = fee.strategyFees.plus(amount);
-    fee.totalFees = fee.totalFees.plus(amount);
-    fee.save();
-  } else {
-    log.warning(
-      'trying to add adding strategy fees for token {} but it has not been created',
-      [tokenId]
-    );
-  }
-}
-
-export function addTreasuryFee(tokenId: string, amount: BigInt): void {
-  let fee = TokenFee.load(tokenId);
-  if (fee !== null) {
-    fee.treasuryFees = fee.treasuryFees.plus(amount);
-    fee.totalFees = fee.totalFees.plus(amount);
-    fee.save();
-  } else {
-    log.warning(
-      'trying to add adding treasury fees for token {} but it has not been created',
-      [tokenId]
-    );
-  }
 }

--- a/src/utils/token-fees.ts
+++ b/src/utils/token-fees.ts
@@ -1,22 +1,23 @@
-import { Token, TokenFees } from '../../generated/schema';
+import { TokenFee } from '../../generated/schema';
 import { BigInt, log } from '@graphprotocol/graph-ts';
 import { BIGINT_ZERO } from './constants';
 
-export function create(tokenId: string): TokenFees {
-  let fees = new TokenFees(tokenId);
+export function create(tokenId: string): TokenFee {
+  let fees = new TokenFee(tokenId);
   fees.strategyFees = BIGINT_ZERO;
   fees.treasuryFees = BIGINT_ZERO;
   fees.totalFees = BIGINT_ZERO;
+  fees.token = tokenId;
   fees.save();
   return fees;
 }
 
 export function addStrategyFee(tokenId: string, amount: BigInt): void {
-  let fees = TokenFees.load(tokenId);
-  if (fees !== null) {
-    fees.strategyFees = fees.strategyFees.plus(amount);
-    fees.totalFees = fees.totalFees.plus(amount);
-    fees.save();
+  let fee = TokenFee.load(tokenId);
+  if (fee !== null) {
+    fee.strategyFees = fee.strategyFees.plus(amount);
+    fee.totalFees = fee.totalFees.plus(amount);
+    fee.save();
   } else {
     log.warning(
       'trying to add adding strategy fees for token {} but it has not been created',
@@ -26,11 +27,11 @@ export function addStrategyFee(tokenId: string, amount: BigInt): void {
 }
 
 export function addTreasuryFee(tokenId: string, amount: BigInt): void {
-  let fees = TokenFees.load(tokenId);
-  if (fees !== null) {
-    fees.treasuryFees = fees.treasuryFees.plus(amount);
-    fees.totalFees = fees.totalFees.plus(amount);
-    fees.save();
+  let fee = TokenFee.load(tokenId);
+  if (fee !== null) {
+    fee.treasuryFees = fee.treasuryFees.plus(amount);
+    fee.totalFees = fee.totalFees.plus(amount);
+    fee.save();
   } else {
     log.warning(
       'trying to add adding treasury fees for token {} but it has not been created',

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,7 +1,7 @@
 import { Address } from '@graphprotocol/graph-ts';
 import { Token } from '../../generated/schema';
 import { ERC20 } from '../../generated/Registry/ERC20';
-import { BIGINT_ZERO, DEFAULT_DECIMALS } from '../utils/constants';
+import { DEFAULT_DECIMALS } from '../utils/constants';
 
 export function getOrCreateToken(address: Address): Token {
   let id = address.toHexString();

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,8 +1,7 @@
 import { Address } from '@graphprotocol/graph-ts';
-import { Token, TokenFees } from '../../generated/schema';
+import { Token } from '../../generated/schema';
 import { ERC20 } from '../../generated/Registry/ERC20';
 import { BIGINT_ZERO, DEFAULT_DECIMALS } from '../utils/constants';
-import * as tokenFeeLibrary from './token-fees';
 
 export function getOrCreateToken(address: Address): Token {
   let id = address.toHexString();
@@ -10,7 +9,6 @@ export function getOrCreateToken(address: Address): Token {
 
   if (token == null) {
     token = new Token(id);
-    let fees = tokenFeeLibrary.create(id);
     let erc20Contract = ERC20.bind(address);
     let decimals = erc20Contract.try_decimals();
     // Using try_cause some values might be missing
@@ -20,7 +18,6 @@ export function getOrCreateToken(address: Address): Token {
     token.decimals = decimals.reverted ? DEFAULT_DECIMALS : decimals.value;
     token.name = name.reverted ? '' : name.value;
     token.symbol = symbol.reverted ? '' : symbol.value;
-    token.fees = fees.id;
     token.save();
   }
   return token as Token;

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -27,7 +27,7 @@ export function getOrCreateToken(address: Address): Token {
   return token as Token;
 }
 
-export function addManagementFee(token: Token, amount: BigInt): void {
+export function addStrategyFee(token: Token, amount: BigInt): void {
   token.strategyFees = token.strategyFees.plus(amount);
   token.totalFees = token.totalFees.plus(amount);
   token.save();

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,8 +1,8 @@
-import { Address } from '@graphprotocol/graph-ts';
+import { Address, BigInt } from '@graphprotocol/graph-ts';
 import { Token } from '../../generated/schema';
 
 import { ERC20 } from '../../generated/Registry/ERC20';
-import { DEFAULT_DECIMALS } from '../utils/constants';
+import { BIGINT_ZERO, DEFAULT_DECIMALS } from '../utils/constants';
 
 export function getOrCreateToken(address: Address): Token {
   let id = address.toHexString();
@@ -19,7 +19,22 @@ export function getOrCreateToken(address: Address): Token {
     token.decimals = decimals.reverted ? DEFAULT_DECIMALS : decimals.value;
     token.name = name.reverted ? '' : name.value;
     token.symbol = symbol.reverted ? '' : symbol.value;
+    token.strategyFees = BIGINT_ZERO;
+    token.treasuryFees = BIGINT_ZERO;
+    token.totalFees = BIGINT_ZERO;
     token.save();
   }
   return token as Token;
+}
+
+export function addManagementFee(token: Token, amount: BigInt): void {
+  token.strategyFees = token.strategyFees.plus(amount);
+  token.totalFees = token.totalFees.plus(amount);
+  token.save();
+}
+
+export function addTreasuryFee(token: Token, amount: BigInt): void {
+  token.treasuryFees = token.treasuryFees.plus(amount);
+  token.totalFees = token.totalFees.plus(amount);
+  token.save();
 }

--- a/src/utils/transfer.ts
+++ b/src/utils/transfer.ts
@@ -8,7 +8,7 @@ import {
   Vault,
 } from '../../generated/schema';
 import { usdcPrice } from './oracle/usdc-oracle';
-import * as yearn from './yearn';
+import * as tokenLibrary from './token';
 
 export function buildIdFromAccountToAccountAndTransaction(
   fromAccount: Account,
@@ -42,14 +42,14 @@ export function getOrCreate(
   let toAddress = Address.fromString(toAccount.id);
   let isFeeToTreasury = toAddress.equals(vault.rewards);
   if (isFeeToTreasury) {
-    yearn.addTreasuryFee(tokenAmountUsdc);
+    tokenLibrary.addTreasuryFee(token, amount);
   }
 
   let isFeeToStrategy = false;
   let strategy = Strategy.load(toAccount.id);
   if (strategy !== null) {
     isFeeToStrategy = true;
-    yearn.addStrategyFee(tokenAmountUsdc);
+    tokenLibrary.addManagementFee(token, amount);
   }
 
   let transfer = Transfer.load(id);

--- a/src/utils/transfer.ts
+++ b/src/utils/transfer.ts
@@ -49,7 +49,7 @@ export function getOrCreate(
   let strategy = Strategy.load(toAccount.id);
   if (strategy !== null) {
     isFeeToStrategy = true;
-    tokenLibrary.addManagementFee(token, amount);
+    tokenLibrary.addStrategyFee(token, amount);
   }
 
   let transfer = Transfer.load(id);

--- a/src/utils/transfer.ts
+++ b/src/utils/transfer.ts
@@ -9,6 +9,7 @@ import {
 } from '../../generated/schema';
 import { usdcPrice } from './oracle/usdc-oracle';
 import * as tokenLibrary from './token';
+import * as tokenFeeLibrary from './token-fees';
 
 export function buildIdFromAccountToAccountAndTransaction(
   fromAccount: Account,
@@ -42,14 +43,14 @@ export function getOrCreate(
   let toAddress = Address.fromString(toAccount.id);
   let isFeeToTreasury = toAddress.equals(vault.rewards);
   if (isFeeToTreasury) {
-    tokenLibrary.addTreasuryFee(token, amount);
+    tokenFeeLibrary.addTreasuryFee(token.id, amount);
   }
 
   let isFeeToStrategy = false;
   let strategy = Strategy.load(toAccount.id);
   if (strategy !== null) {
     isFeeToStrategy = true;
-    tokenLibrary.addStrategyFee(token, amount);
+    tokenFeeLibrary.addStrategyFee(token.id, amount);
   }
 
   let transfer = Transfer.load(id);


### PR DESCRIPTION
Sadly we can't reliably use the on chain oracle to aggregate all fees to usd, as values are often $0 and we need this to be accurate data. Therefore we'll have to group all fees by token in their native amount, then retroactively use historical pricing data to calculate earnings for each token at a certain block and then sum together to get total protocol fees. 

e.g. 
```
tokens(block:{number:12584092}, where:{totalFees_not:"0"}, first:1000) {
    totalFees
    id
}
```