### PR TITLE
fix: update apiversion constant for fantom custom vaults to 0.4.3

### DIFF
--- a/src/mappings/ftm/yv2CRVVaultMappings.ts
+++ b/src/mappings/ftm/yv2CRVVaultMappings.ts
@@ -33,7 +33,7 @@ import {
   ZERO_ADDRESS,
   FTM_YV_2CRV_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
   EXPERIMENTAL,
 } from '../../utils/constants';
@@ -52,7 +52,7 @@ function createftmYv2CRVVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvDAIVaultMappings.ts
+++ b/src/mappings/ftm/yvDAIVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_DAI_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFTMYvDAIVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvFTMVaultMappings.ts
+++ b/src/mappings/ftm/yvFTMVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_FTM_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFtmYvFTMVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvMIMVaultMappings.ts
+++ b/src/mappings/ftm/yvMIMVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_MIM_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFTMYvMIMVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvUSDCVaultMappings.ts
+++ b/src/mappings/ftm/yvUSDCVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_USDC_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFTMYvUSDCVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvYFIVaultMappings.ts
+++ b/src/mappings/ftm/yvYFIVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_YFI_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFTMYvYFIVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,7 +71,7 @@ export let ETH_MAINNET_REGISTRY_ADDRESS_V2 =
   '0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804';
 export const ENDORSED = 'Endorsed';
 export const EXPERIMENTAL = 'Experimental';
-export const API_VERSION_0_4_3 = '0.4.3f';
+export const API_VERSION_0_4_3 = '0.4.3';
 export const API_VERSION_0_3_5 = '0.3.5';
 export const ETH_MAINNET_NETWORK = 'mainnet';
 export const FTM_MAINNET_NETWORK = 'fantom';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,7 +71,7 @@ export let ETH_MAINNET_REGISTRY_ADDRESS_V2 =
   '0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804';
 export const ENDORSED = 'Endorsed';
 export const EXPERIMENTAL = 'Experimental';
-export const API_VERSION_0_4_2 = '0.4.2';
+export const API_VERSION_0_4_3 = '0.4.3f';
 export const API_VERSION_0_3_5 = '0.3.5';
 export const ETH_MAINNET_NETWORK = 'mainnet';
 export const FTM_MAINNET_NETWORK = 'fantom';


### PR DESCRIPTION
I fixed the bug of issue #166   for the dai vault and the other custom fantom vaults. I did this by just changing the constant to 0.4.3. However, I'm not sure if passing the api_version as a param is necessary at all. But I think refactoring this would be out of scope and also needs extra testing. 
TL;DR I think updating the constant is a pragmatic fix for the issue.