### PR TITLE
169 add withdrawal queue field to subgraph

### DIFF
--- a/abis/Vault.json
+++ b/abis/Vault.json
@@ -338,6 +338,7 @@
     { "name": "UpdateDepositLimit", "inputs": [{ "type": "uint256", "name": "depositLimit", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "StrategyRemovedFromQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },
     { "name": "StrategyAddedToQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },
+    { "name": "UpdateWithdrawalQueue", "inputs": [{ "name": "queue", "type": "address[20]", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "UpdateRewards", "inputs": [{ "type": "address", "name": "rewards", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "management", "outputs": [{ "type": "address", "name": "" }], "inputs": [], "stateMutability": "view", "type": "function", "gas": 2981 },
 

--- a/abis/Vault.json
+++ b/abis/Vault.json
@@ -338,7 +338,7 @@
     { "name": "UpdateDepositLimit", "inputs": [{ "type": "uint256", "name": "depositLimit", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "StrategyRemovedFromQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },
     { "name": "StrategyAddedToQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },
-    { "name": "UpdateWithdrawalQueue", "inputs": [{ "name": "queue", "type": "address[20]", "indexed": false }], "anonymous": false, "type": "event" },
+    { "name": "UpdateWithdrawalQueue", "inputs": [{ "name": "queue", "type": "address[]", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "UpdateRewards", "inputs": [{ "type": "address", "name": "rewards", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "management", "outputs": [{ "type": "address", "name": "" }], "inputs": [], "stateMutability": "view", "type": "function", "gas": 2981 },
 

--- a/abis/Vault.json
+++ b/abis/Vault.json
@@ -338,7 +338,7 @@
     { "name": "UpdateDepositLimit", "inputs": [{ "type": "uint256", "name": "depositLimit", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "StrategyRemovedFromQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },
     { "name": "StrategyAddedToQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },
-    { "name": "UpdateWithdrawalQueue", "inputs": [{ "name": "queue", "type": "address[]", "indexed": false }], "anonymous": false, "type": "event" },
+    { "name": "UpdateWithdrawalQueue", "inputs": [{ "name": "queue", "type": "address[20]", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "UpdateRewards", "inputs": [{ "type": "address", "name": "rewards", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "management", "outputs": [{ "type": "address", "name": "" }], "inputs": [], "stateMutability": "view", "type": "function", "gas": 2981 },
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -141,6 +141,8 @@ type Vault @entity {
   deposits: [Deposit!]! @derivedFrom(field: "vault")
   "Token withdrawals from the Vault"
   withdrawals: [Withdrawal!]! @derivedFrom(field: "vault")
+  "withdrawl queue of strategies"
+  withdrawalQueue:[Strategy!]! 
   "Transfers of Vault Shares"
   transfers: [Transfer!]! @derivedFrom(field: "vault")
   "Tags attached to the Vault"

--- a/src/mappings/curveSETHVaultMappings.ts
+++ b/src/mappings/curveSETHVaultMappings.ts
@@ -1,4 +1,3 @@
-import { log, BigInt } from '@graphprotocol/graph-ts';
 import {
   UpdateDepositLimit,
   UpdateGovernance,
@@ -6,22 +5,18 @@ import {
   UpdateManagement,
 } from '../../generated/CurveSETHVault/Vault';
 import {
-  Vault as VaultContract,
-  UpdatePerformanceFee as UpdatePerformanceFeeEvent,
-  UpdateManagementFee as UpdateManagementFeeEvent,
   StrategyAdded1 as StrategyAddedV2Event,
+  UpdateManagementFee as UpdateManagementFeeEvent,
+  UpdatePerformanceFee as UpdatePerformanceFeeEvent,
+  Vault as VaultContract,
 } from '../../generated/Registry/Vault';
-import { Vault } from '../../generated/schema';
 import { isEventBlockNumberLt } from '../utils/commons';
 import {
   BIGINT_ZERO,
   CURVE_SETH_VAULT_END_BLOCK_CUSTOM,
 } from '../utils/constants';
 import * as strategyLibrary from '../utils/strategy/strategy';
-import {
-  getOrCreateTransactionFromCall,
-  getOrCreateTransactionFromEvent,
-} from '../utils/transaction';
+import { getOrCreateTransactionFromEvent } from '../utils/transaction';
 import * as vaultLibrary from '../utils/vault/vault';
 
 /**

--- a/src/mappings/ftm/yv2CRVVaultMappings.ts
+++ b/src/mappings/ftm/yv2CRVVaultMappings.ts
@@ -812,7 +812,9 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(
+  event: UpdateWithdrawalQueue
+): void {
   if (
     isEventBlockNumberLt(
       'ftmYv2CRVVault_UpdateWithdrawalQueue',

--- a/src/mappings/ftm/yv2CRVVaultMappings.ts
+++ b/src/mappings/ftm/yv2CRVVaultMappings.ts
@@ -812,20 +812,20 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'ftmYv2CRVVault_UpdateWithdrawlQueue',
+      'ftmYv2CRVVault_UpdateWithdrawalQueue',
       event.block,
       FTM_YV_2CRV_VAULT_END_BLOCK_CUSTOM
     )
   ) {
     let ethTransaction = getOrCreateTransactionFromEvent(
       event,
-      'ftmYv2CRVVault_UpdateWithdrawlQueue'
+      'ftmYv2CRVVault_UpdateWithdrawalQueue'
     );
 
-    vaultLibrary.updateWithdrawlQueue(
+    vaultLibrary.UpdateWithdrawalQueue(
       event.params.queue,
       ethTransaction,
       event

--- a/src/mappings/ftm/yv2CRVVaultMappings.ts
+++ b/src/mappings/ftm/yv2CRVVaultMappings.ts
@@ -280,12 +280,17 @@ export function handleStrategyMigrated(event: StrategyMigrated): void {
           null,
           ethTransaction
         );
-        vaultLibrary.strategyRemovedFromQueue(
-          oldStrategyAddress,
-          ethTransaction,
-          event
-        );
       }
+      //We can now remove the old strat from the queue
+      log.info('[Strategy Migrated] Removing old strategy', [
+        oldStrategyAddress.toHexString(),
+      ]);
+
+      vaultLibrary.strategyRemovedFromQueue(
+        oldStrategyAddress,
+        ethTransaction,
+        event
+      );
     }
   }
 }

--- a/src/mappings/ftm/yv2CRVVaultMappings.ts
+++ b/src/mappings/ftm/yv2CRVVaultMappings.ts
@@ -25,6 +25,7 @@ import {
   StrategyAddedToQueue as StrategyAddedToQueueEvent,
   StrategyRemovedFromQueue as StrategyRemovedFromQueueEvent,
   UpdateRewards as UpdateRewardsEvent,
+  UpdateWithdrawalQueue,
 } from '../../../generated/ftmYv2CRVVault/Vault';
 import { Strategy, Transaction, Vault } from '../../../generated/schema';
 import { isEventBlockNumberLt, printCallInfo } from '../../utils/commons';
@@ -800,6 +801,27 @@ export function handleStrategyRemovedFromQueue(
     );
     vaultLibrary.strategyRemovedFromQueue(
       event.params.strategy,
+      ethTransaction,
+      event
+    );
+  }
+}
+
+export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+  if (
+    isEventBlockNumberLt(
+      'ftmYv2CRVVault_UpdateWithdrawlQueue',
+      event.block,
+      FTM_YV_2CRV_VAULT_END_BLOCK_CUSTOM
+    )
+  ) {
+    let ethTransaction = getOrCreateTransactionFromEvent(
+      event,
+      'ftmYv2CRVVault_UpdateWithdrawlQueue'
+    );
+
+    vaultLibrary.updateWithdrawlQueue(
+      event.params.queue,
       ethTransaction,
       event
     );

--- a/src/mappings/ftm/yv2CRVVaultMappings.ts
+++ b/src/mappings/ftm/yv2CRVVaultMappings.ts
@@ -33,7 +33,7 @@ import {
   ZERO_ADDRESS,
   FTM_YV_2CRV_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
   EXPERIMENTAL,
 } from '../../utils/constants';
@@ -52,7 +52,7 @@ function createftmYv2CRVVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvDAIVaultMappings.ts
+++ b/src/mappings/ftm/yvDAIVaultMappings.ts
@@ -281,12 +281,17 @@ export function handleStrategyMigrated(event: StrategyMigrated): void {
           null,
           ethTransaction
         );
-        vaultLibrary.strategyRemovedFromQueue(
-          oldStrategyAddress,
-          ethTransaction,
-          event
-        );
       }
+      //We can now remove the old strat from the queue
+      log.info('[Strategy Migrated] Removing old strategy', [
+        oldStrategyAddress.toHexString(),
+      ]);
+
+      vaultLibrary.strategyRemovedFromQueue(
+        oldStrategyAddress,
+        ethTransaction,
+        event
+      );
     }
   }
 }

--- a/src/mappings/ftm/yvDAIVaultMappings.ts
+++ b/src/mappings/ftm/yvDAIVaultMappings.ts
@@ -812,20 +812,20 @@ export function handleStrategyRemovedFromQueue(
     );
   }
 }
-export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'ftmYvDAIVault_UpdateWithdrawlQueue',
+      'ftmYvDAIVault_UpdateWithdrawalQueue',
       event.block,
       FTM_YV_DAI_VAULT_END_BLOCK_CUSTOM
     )
   ) {
     let ethTransaction = getOrCreateTransactionFromEvent(
       event,
-      'ftmYvDAIVault_UpdateWithdrawlQueue'
+      'ftmYvDAIVault_UpdateWithdrawalQueue'
     );
 
-    vaultLibrary.updateWithdrawlQueue(
+    vaultLibrary.UpdateWithdrawalQueue(
       event.params.queue,
       ethTransaction,
       event

--- a/src/mappings/ftm/yvDAIVaultMappings.ts
+++ b/src/mappings/ftm/yvDAIVaultMappings.ts
@@ -812,7 +812,9 @@ export function handleStrategyRemovedFromQueue(
     );
   }
 }
-export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(
+  event: UpdateWithdrawalQueue
+): void {
   if (
     isEventBlockNumberLt(
       'ftmYvDAIVault_UpdateWithdrawalQueue',

--- a/src/mappings/ftm/yvDAIVaultMappings.ts
+++ b/src/mappings/ftm/yvDAIVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_DAI_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFTMYvDAIVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvDAIVaultMappings.ts
+++ b/src/mappings/ftm/yvDAIVaultMappings.ts
@@ -25,6 +25,7 @@ import {
   StrategyAddedToQueue as StrategyAddedToQueueEvent,
   StrategyRemovedFromQueue as StrategyRemovedFromQueueEvent,
   UpdateRewards as UpdateRewardsEvent,
+  UpdateWithdrawalQueue,
 } from '../../../generated/ftmYvDAIVault/Vault';
 import { Strategy, Transaction, Vault } from '../../../generated/schema';
 import { isEventBlockNumberLt, printCallInfo } from '../../utils/commons';
@@ -801,6 +802,26 @@ export function handleStrategyRemovedFromQueue(
     );
     vaultLibrary.strategyRemovedFromQueue(
       event.params.strategy,
+      ethTransaction,
+      event
+    );
+  }
+}
+export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+  if (
+    isEventBlockNumberLt(
+      'ftmYvDAIVault_UpdateWithdrawlQueue',
+      event.block,
+      FTM_YV_DAI_VAULT_END_BLOCK_CUSTOM
+    )
+  ) {
+    let ethTransaction = getOrCreateTransactionFromEvent(
+      event,
+      'ftmYvDAIVault_UpdateWithdrawlQueue'
+    );
+
+    vaultLibrary.updateWithdrawlQueue(
+      event.params.queue,
       ethTransaction,
       event
     );

--- a/src/mappings/ftm/yvFTMVaultMappings.ts
+++ b/src/mappings/ftm/yvFTMVaultMappings.ts
@@ -25,6 +25,7 @@ import {
   StrategyAddedToQueue as StrategyAddedToQueueEvent,
   StrategyRemovedFromQueue as StrategyRemovedFromQueueEvent,
   UpdateRewards as UpdateRewardsEvent,
+  UpdateWithdrawalQueue,
 } from '../../../generated/ftmYvWFTMVault/Vault';
 import { Strategy, Transaction, Vault } from '../../../generated/schema';
 import { isEventBlockNumberLt, printCallInfo } from '../../utils/commons';
@@ -800,6 +801,27 @@ export function handleStrategyRemovedFromQueue(
     );
     vaultLibrary.strategyRemovedFromQueue(
       event.params.strategy,
+      ethTransaction,
+      event
+    );
+  }
+}
+
+export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+  if (
+    isEventBlockNumberLt(
+      'ftmYvFTMVault_UpdateWithdrawlQueue',
+      event.block,
+      FTM_YV_FTM_VAULT_END_BLOCK_CUSTOM
+    )
+  ) {
+    let ethTransaction = getOrCreateTransactionFromEvent(
+      event,
+      'ftmYvFTMVault_UpdateWithdrawlQueue'
+    );
+
+    vaultLibrary.updateWithdrawlQueue(
+      event.params.queue,
       ethTransaction,
       event
     );

--- a/src/mappings/ftm/yvFTMVaultMappings.ts
+++ b/src/mappings/ftm/yvFTMVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_FTM_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFtmYvFTMVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvFTMVaultMappings.ts
+++ b/src/mappings/ftm/yvFTMVaultMappings.ts
@@ -280,12 +280,17 @@ export function handleStrategyMigrated(event: StrategyMigrated): void {
           null,
           ethTransaction
         );
-        vaultLibrary.strategyRemovedFromQueue(
-          oldStrategyAddress,
-          ethTransaction,
-          event
-        );
       }
+      //We can now remove the old strat from the queue
+      log.info('[Strategy Migrated] Removing old strategy', [
+        oldStrategyAddress.toHexString(),
+      ]);
+
+      vaultLibrary.strategyRemovedFromQueue(
+        oldStrategyAddress,
+        ethTransaction,
+        event
+      );
     }
   }
 }

--- a/src/mappings/ftm/yvFTMVaultMappings.ts
+++ b/src/mappings/ftm/yvFTMVaultMappings.ts
@@ -812,7 +812,9 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(
+  event: UpdateWithdrawalQueue
+): void {
   if (
     isEventBlockNumberLt(
       'ftmYvFTMVault_UpdateWithdrawalQueue',
@@ -822,7 +824,7 @@ export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void 
   ) {
     let ethTransaction = getOrCreateTransactionFromEvent(
       event,
-      'ftmYvFTMVault_UpdateWithdrawalQueue
+      'ftmYvFTMVault_UpdateWithdrawalQueue'
     );
 
     vaultLibrary.UpdateWithdrawalQueue(

--- a/src/mappings/ftm/yvFTMVaultMappings.ts
+++ b/src/mappings/ftm/yvFTMVaultMappings.ts
@@ -812,20 +812,20 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'ftmYvFTMVault_UpdateWithdrawlQueue',
+      'ftmYvFTMVault_UpdateWithdrawalQueue',
       event.block,
       FTM_YV_FTM_VAULT_END_BLOCK_CUSTOM
     )
   ) {
     let ethTransaction = getOrCreateTransactionFromEvent(
       event,
-      'ftmYvFTMVault_UpdateWithdrawlQueue'
+      'ftmYvFTMVault_UpdateWithdrawalQueue
     );
 
-    vaultLibrary.updateWithdrawlQueue(
+    vaultLibrary.UpdateWithdrawalQueue(
       event.params.queue,
       ethTransaction,
       event

--- a/src/mappings/ftm/yvMIMVaultMappings.ts
+++ b/src/mappings/ftm/yvMIMVaultMappings.ts
@@ -813,20 +813,20 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'ftmYvMIMVault_UpdateWithdrawlQueue',
+      'ftmYvMIMVault_UpdateWithdrawalQueue',
       event.block,
       FTM_YV_MIM_VAULT_END_BLOCK_CUSTOM
     )
   ) {
     let ethTransaction = getOrCreateTransactionFromEvent(
       event,
-      'ftmYvMIMVault_UpdateWithdrawlQueue'
+      'ftmYvMIMVault_UpdateWithdrawalQueue'
     );
 
-    vaultLibrary.updateWithdrawlQueue(
+    vaultLibrary.UpdateWithdrawalQueue(
       event.params.queue,
       ethTransaction,
       event

--- a/src/mappings/ftm/yvMIMVaultMappings.ts
+++ b/src/mappings/ftm/yvMIMVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_MIM_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFTMYvMIMVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvMIMVaultMappings.ts
+++ b/src/mappings/ftm/yvMIMVaultMappings.ts
@@ -281,12 +281,17 @@ export function handleStrategyMigrated(event: StrategyMigrated): void {
           null,
           ethTransaction
         );
-        vaultLibrary.strategyRemovedFromQueue(
-          oldStrategyAddress,
-          ethTransaction,
-          event
-        );
       }
+      //We can now remove the old strat from the queue
+      log.info('[Strategy Migrated] Removing old strategy', [
+        oldStrategyAddress.toHexString(),
+      ]);
+
+      vaultLibrary.strategyRemovedFromQueue(
+        oldStrategyAddress,
+        ethTransaction,
+        event
+      );
     }
   }
 }

--- a/src/mappings/ftm/yvMIMVaultMappings.ts
+++ b/src/mappings/ftm/yvMIMVaultMappings.ts
@@ -25,6 +25,7 @@ import {
   StrategyAddedToQueue as StrategyAddedToQueueEvent,
   StrategyRemovedFromQueue as StrategyRemovedFromQueueEvent,
   UpdateRewards as UpdateRewardsEvent,
+  UpdateWithdrawalQueue,
 } from '../../../generated/ftmYvMIMVault/Vault';
 import { Strategy, Transaction, Vault } from '../../../generated/schema';
 import { isEventBlockNumberLt, printCallInfo } from '../../utils/commons';
@@ -801,6 +802,27 @@ export function handleStrategyRemovedFromQueue(
     );
     vaultLibrary.strategyRemovedFromQueue(
       event.params.strategy,
+      ethTransaction,
+      event
+    );
+  }
+}
+
+export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+  if (
+    isEventBlockNumberLt(
+      'ftmYvMIMVault_UpdateWithdrawlQueue',
+      event.block,
+      FTM_YV_MIM_VAULT_END_BLOCK_CUSTOM
+    )
+  ) {
+    let ethTransaction = getOrCreateTransactionFromEvent(
+      event,
+      'ftmYvMIMVault_UpdateWithdrawlQueue'
+    );
+
+    vaultLibrary.updateWithdrawlQueue(
+      event.params.queue,
       ethTransaction,
       event
     );

--- a/src/mappings/ftm/yvMIMVaultMappings.ts
+++ b/src/mappings/ftm/yvMIMVaultMappings.ts
@@ -813,7 +813,9 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(
+  event: UpdateWithdrawalQueue
+): void {
   if (
     isEventBlockNumberLt(
       'ftmYvMIMVault_UpdateWithdrawalQueue',

--- a/src/mappings/ftm/yvUSDCVaultMappings.ts
+++ b/src/mappings/ftm/yvUSDCVaultMappings.ts
@@ -281,12 +281,17 @@ export function handleStrategyMigrated(event: StrategyMigrated): void {
           null,
           ethTransaction
         );
-        vaultLibrary.strategyRemovedFromQueue(
-          oldStrategyAddress,
-          ethTransaction,
-          event
-        );
       }
+      //We can now remove the old strat from the queue
+      log.info('[Strategy Migrated] Removing old strategy', [
+        oldStrategyAddress.toHexString(),
+      ]);
+
+      vaultLibrary.strategyRemovedFromQueue(
+        oldStrategyAddress,
+        ethTransaction,
+        event
+      );
     }
   }
 }

--- a/src/mappings/ftm/yvUSDCVaultMappings.ts
+++ b/src/mappings/ftm/yvUSDCVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_USDC_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFTMYvUSDCVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvUSDCVaultMappings.ts
+++ b/src/mappings/ftm/yvUSDCVaultMappings.ts
@@ -813,7 +813,9 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(
+  event: UpdateWithdrawalQueue
+): void {
   if (
     isEventBlockNumberLt(
       'ftmYvUSDCVault_UpdateWithdrawalQueue',

--- a/src/mappings/ftm/yvUSDCVaultMappings.ts
+++ b/src/mappings/ftm/yvUSDCVaultMappings.ts
@@ -25,6 +25,7 @@ import {
   StrategyAddedToQueue as StrategyAddedToQueueEvent,
   StrategyRemovedFromQueue as StrategyRemovedFromQueueEvent,
   UpdateRewards as UpdateRewardsEvent,
+  UpdateWithdrawalQueue,
 } from '../../../generated/ftmYvUSDCVault/Vault';
 import { Strategy, Transaction, Vault } from '../../../generated/schema';
 import { isEventBlockNumberLt, printCallInfo } from '../../utils/commons';
@@ -801,6 +802,27 @@ export function handleStrategyRemovedFromQueue(
     );
     vaultLibrary.strategyRemovedFromQueue(
       event.params.strategy,
+      ethTransaction,
+      event
+    );
+  }
+}
+
+export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+  if (
+    isEventBlockNumberLt(
+      'ftmYvUSDCVault_UpdateWithdrawlQueue',
+      event.block,
+      FTM_YV_USDC_VAULT_END_BLOCK_CUSTOM
+    )
+  ) {
+    let ethTransaction = getOrCreateTransactionFromEvent(
+      event,
+      'ftmYvUSDCVault_UpdateWithdrawlQueue'
+    );
+
+    vaultLibrary.updateWithdrawlQueue(
+      event.params.queue,
       ethTransaction,
       event
     );

--- a/src/mappings/ftm/yvUSDCVaultMappings.ts
+++ b/src/mappings/ftm/yvUSDCVaultMappings.ts
@@ -813,20 +813,20 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'ftmYvUSDCVault_UpdateWithdrawlQueue',
+      'ftmYvUSDCVault_UpdateWithdrawalQueue',
       event.block,
       FTM_YV_USDC_VAULT_END_BLOCK_CUSTOM
     )
   ) {
     let ethTransaction = getOrCreateTransactionFromEvent(
       event,
-      'ftmYvUSDCVault_UpdateWithdrawlQueue'
+      'ftmYvUSDCVault_UpdateWithdrawalQueue'
     );
 
-    vaultLibrary.updateWithdrawlQueue(
+    vaultLibrary.UpdateWithdrawalQueue(
       event.params.queue,
       ethTransaction,
       event

--- a/src/mappings/ftm/yvYFIVaultMappings.ts
+++ b/src/mappings/ftm/yvYFIVaultMappings.ts
@@ -812,20 +812,20 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'ftmYvYFIVault_UpdateWithdrawlQueue',
+      'ftmYvYFIVault_UpdateWithdrawalQueue',
       event.block,
       FTM_YV_YFI_VAULT_END_BLOCK_CUSTOM
     )
   ) {
     let ethTransaction = getOrCreateTransactionFromEvent(
       event,
-      'ftmYvYFIVault_UpdateWithdrawlQueue'
+      'ftmYvYFIVault_UpdateWithdrawalQueue'
     );
 
-    vaultLibrary.updateWithdrawlQueue(
+    vaultLibrary.UpdateWithdrawalQueue(
       event.params.queue,
       ethTransaction,
       event

--- a/src/mappings/ftm/yvYFIVaultMappings.ts
+++ b/src/mappings/ftm/yvYFIVaultMappings.ts
@@ -34,7 +34,7 @@ import {
   FTM_YV_YFI_VAULT_END_BLOCK_CUSTOM,
   DON_T_CREATE_VAULT_TEMPLATE,
   EXPERIMENTAL,
-  API_VERSION_0_4_2,
+  API_VERSION_0_4_3,
   FTM_MAINNET_REGISTRY_ADDRESS,
 } from '../../utils/constants';
 import * as strategyLibrary from '../../utils/strategy/strategy';
@@ -52,7 +52,7 @@ function createFTMYvYFIVaultIfNeeded(
     // Note: This custom mapping is used ONLY in Fantom. So, we can hardcoded the address.
     changetype<Address>(Address.fromHexString(FTM_MAINNET_REGISTRY_ADDRESS)),
     EXPERIMENTAL,
-    API_VERSION_0_4_2,
+    API_VERSION_0_4_3,
     transaction,
     DON_T_CREATE_VAULT_TEMPLATE
   );

--- a/src/mappings/ftm/yvYFIVaultMappings.ts
+++ b/src/mappings/ftm/yvYFIVaultMappings.ts
@@ -280,12 +280,17 @@ export function handleStrategyMigrated(event: StrategyMigrated): void {
           null,
           ethTransaction
         );
-        vaultLibrary.strategyRemovedFromQueue(
-          oldStrategyAddress,
-          ethTransaction,
-          event
-        );
       }
+      //We can now remove the old strat from the queue
+      log.info('[Strategy Migrated] Removing old strategy', [
+        oldStrategyAddress.toHexString(),
+      ]);
+
+      vaultLibrary.strategyRemovedFromQueue(
+        oldStrategyAddress,
+        ethTransaction,
+        event
+      );
     }
   }
 }

--- a/src/mappings/ftm/yvYFIVaultMappings.ts
+++ b/src/mappings/ftm/yvYFIVaultMappings.ts
@@ -812,7 +812,9 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(
+  event: UpdateWithdrawalQueue
+): void {
   if (
     isEventBlockNumberLt(
       'ftmYvYFIVault_UpdateWithdrawalQueue',

--- a/src/mappings/ftm/yvYFIVaultMappings.ts
+++ b/src/mappings/ftm/yvYFIVaultMappings.ts
@@ -25,6 +25,7 @@ import {
   StrategyAddedToQueue as StrategyAddedToQueueEvent,
   StrategyRemovedFromQueue as StrategyRemovedFromQueueEvent,
   UpdateRewards as UpdateRewardsEvent,
+  UpdateWithdrawalQueue,
 } from '../../../generated/ftmYvYFIVault/Vault';
 import { Strategy, Transaction, Vault } from '../../../generated/schema';
 import { isEventBlockNumberLt, printCallInfo } from '../../utils/commons';
@@ -800,6 +801,27 @@ export function handleStrategyRemovedFromQueue(
     );
     vaultLibrary.strategyRemovedFromQueue(
       event.params.strategy,
+      ethTransaction,
+      event
+    );
+  }
+}
+
+export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+  if (
+    isEventBlockNumberLt(
+      'ftmYvYFIVault_UpdateWithdrawlQueue',
+      event.block,
+      FTM_YV_YFI_VAULT_END_BLOCK_CUSTOM
+    )
+  ) {
+    let ethTransaction = getOrCreateTransactionFromEvent(
+      event,
+      'ftmYvYFIVault_UpdateWithdrawlQueue'
+    );
+
+    vaultLibrary.updateWithdrawlQueue(
+      event.params.queue,
       ethTransaction,
       event
     );

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -696,14 +696,14 @@ export function handleStrategyRemovedFromQueue(
     event
   );
 }
-//handleUpdateWithdrawlQueue -> 0x695ac3ac73f08f2002284ffe563cefe798ee2878a5e04219522e2e99eb89d168
-export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+//UpdateWithdrawalQueue -> 0x695ac3ac73f08f2002284ffe563cefe798ee2878a5e04219522e2e99eb89d168
+export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
   let ethTransaction = getOrCreateTransactionFromEvent(
     event,
-    'UpdateWithdrawlQueue'
+    'UpdateWithdrawalQueue'
   );
 
-  vaultLibrary.updateWithdrawlQueue(event.params.queue, ethTransaction, event);
+  vaultLibrary.UpdateWithdrawalQueue(event.params.queue, ethTransaction, event);
 }
 
 export function handleUpdateRewards(event: UpdateRewardsEvent): void {

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -200,6 +200,7 @@ export function handleStrategyMigrated(event: StrategyMigratedEvent): void {
       ethTransaction
     );
 
+    //Create new strategy
     if (Strategy.load(newStrategyAddress.toHexString()) !== null) {
       log.warning(
         '[Strategy Migrated] Migrating to strategy {} but it has already been created',
@@ -218,12 +219,18 @@ export function handleStrategyMigrated(event: StrategyMigratedEvent): void {
         null,
         ethTransaction
       );
-      vaultLibrary.strategyRemovedFromQueue(
-        oldStrategyAddress,
-        ethTransaction,
-        event
-      );
     }
+
+    //We can now remove the old strat from the queue
+    log.info('[Strategy Migrated] Removing old strategy', [
+      oldStrategyAddress.toHexString(),
+    ]);
+
+    vaultLibrary.strategyRemovedFromQueue(
+      oldStrategyAddress,
+      ethTransaction,
+      event
+    );
   }
 }
 
@@ -660,7 +667,7 @@ export function handleUpdateManagementFee(
     event.params.managementFee
   );
 }
-
+//strategyAddedToQueue 0xa8727d412c6fa1e2497d6d6f275e2d9fe4d9318d5b793632e60ad9d38ee8f1fa
 export function handleStrategyAddedToQueue(
   event: StrategyAddedToQueueEvent
 ): void {
@@ -675,7 +682,7 @@ export function handleStrategyAddedToQueue(
     event
   );
 }
-
+//strategyRemovedFromQueue 0x8e1ec3c16d6a67ea8effe2ac7adef9c2de0bc0dc47c49cdf18f6a8b0048085be
 export function handleStrategyRemovedFromQueue(
   event: StrategyRemovedFromQueueEvent
 ): void {
@@ -689,7 +696,7 @@ export function handleStrategyRemovedFromQueue(
     event
   );
 }
-
+//handleUpdateWithdrawlQueue -> 0x695ac3ac73f08f2002284ffe563cefe798ee2878a5e04219522e2e99eb89d168
 export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
   let ethTransaction = getOrCreateTransactionFromEvent(
     event,

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -31,6 +31,7 @@ import {
   StrategyUpdatePerformanceFee as StrategyUpdatePerformanceFeeEvent,
   StrategyUpdateMinDebtPerHarvest as StrategyUpdateMinDebtPerHarvestEvent,
   StrategyUpdateMaxDebtPerHarvest as StrategyUpdateMaxDebtPerHarvestEvent,
+  UpdateWithdrawalQueue,
 } from '../../generated/Registry/Vault';
 import { Strategy, StrategyMigration, Vault } from '../../generated/schema';
 import { printCallInfo } from '../utils/commons';
@@ -684,6 +685,21 @@ export function handleStrategyRemovedFromQueue(
   );
   vaultLibrary.strategyRemovedFromQueue(
     event.params.strategy,
+    ethTransaction,
+    event
+  );
+}
+
+export function handleUpdateWithdrawlQueue(
+  event: UpdateWithdrawalQueue
+): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateWithdrawlQueue'
+  );
+
+  vaultLibrary.updateWithdrawlQueue(
+    event.params.queue,
     ethTransaction,
     event
   );

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -690,19 +690,13 @@ export function handleStrategyRemovedFromQueue(
   );
 }
 
-export function handleUpdateWithdrawlQueue(
-  event: UpdateWithdrawalQueue
-): void {
+export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
   let ethTransaction = getOrCreateTransactionFromEvent(
     event,
     'UpdateWithdrawlQueue'
   );
 
-  vaultLibrary.updateWithdrawlQueue(
-    event.params.queue,
-    ethTransaction,
-    event
-  );
+  vaultLibrary.updateWithdrawlQueue(event.params.queue, ethTransaction, event);
 }
 
 export function handleUpdateRewards(event: UpdateRewardsEvent): void {

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -697,7 +697,9 @@ export function handleStrategyRemovedFromQueue(
   );
 }
 //UpdateWithdrawalQueue -> 0x695ac3ac73f08f2002284ffe563cefe798ee2878a5e04219522e2e99eb89d168
-export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(
+  event: UpdateWithdrawalQueue
+): void {
   let ethTransaction = getOrCreateTransactionFromEvent(
     event,
     'UpdateWithdrawalQueue'

--- a/src/mappings/yvLinkVaultMappings.ts
+++ b/src/mappings/yvLinkVaultMappings.ts
@@ -743,7 +743,9 @@ export function handleStrategyAddedToQueue(
   }
 }
 
-export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(
+  event: UpdateWithdrawalQueue
+): void {
   if (
     isEventBlockNumberLt(
       'yvLinkVault_UpdateWithdrawalQueue',

--- a/src/mappings/yvLinkVaultMappings.ts
+++ b/src/mappings/yvLinkVaultMappings.ts
@@ -741,7 +741,7 @@ export function handleStrategyAddedToQueue(
 export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'yvLinkVault_StrategyAddedToQueue',
+      'yvLinkVault_UpdateWithdrawlQueue',
       event.block,
       YV_LINK_VAULT_END_BLOCK_CUSTOM
     )

--- a/src/mappings/yvLinkVaultMappings.ts
+++ b/src/mappings/yvLinkVaultMappings.ts
@@ -233,12 +233,17 @@ export function handleStrategyMigrated(event: StrategyMigrated): void {
           null,
           ethTransaction
         );
-        vaultLibrary.strategyRemovedFromQueue(
-          oldStrategyAddress,
-          ethTransaction,
-          event
-        );
       }
+      //We can now remove the old strat from the queue
+      log.info('[Strategy Migrated] Removing old strategy', [
+        oldStrategyAddress.toHexString(),
+      ]);
+
+      vaultLibrary.strategyRemovedFromQueue(
+        oldStrategyAddress,
+        ethTransaction,
+        event
+      );
     }
   }
 }

--- a/src/mappings/yvLinkVaultMappings.ts
+++ b/src/mappings/yvLinkVaultMappings.ts
@@ -743,20 +743,20 @@ export function handleStrategyAddedToQueue(
   }
 }
 
-export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'yvLinkVault_UpdateWithdrawlQueue',
+      'yvLinkVault_UpdateWithdrawalQueue',
       event.block,
       YV_LINK_VAULT_END_BLOCK_CUSTOM
     )
   ) {
     let ethTransaction = getOrCreateTransactionFromEvent(
       event,
-      'yvLinkVault_UpdateWithdrawlQueue'
+      'yvLinkVault_UpdateWithdrawalQueue'
     );
 
-    vaultLibrary.updateWithdrawlQueue(
+    vaultLibrary.UpdateWithdrawalQueue(
       event.params.queue,
       ethTransaction,
       event

--- a/src/mappings/yvLinkVaultMappings.ts
+++ b/src/mappings/yvLinkVaultMappings.ts
@@ -42,6 +42,7 @@ import {
   UpdateGovernance,
   UpdateGuardian,
   UpdateManagement,
+  UpdateWithdrawalQueue,
 } from '../../generated/YvLinkVault/Vault';
 
 function createYvLinkVaultIfNeeded(
@@ -731,6 +732,27 @@ export function handleStrategyAddedToQueue(
 
     vaultLibrary.strategyAddedToQueue(
       event.params.strategy,
+      ethTransaction,
+      event
+    );
+  }
+}
+
+export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+  if (
+    isEventBlockNumberLt(
+      'yvLinkVault_StrategyAddedToQueue',
+      event.block,
+      YV_LINK_VAULT_END_BLOCK_CUSTOM
+    )
+  ) {
+    let ethTransaction = getOrCreateTransactionFromEvent(
+      event,
+      'yvLinkVault_UpdateWithdrawlQueue'
+    );
+
+    vaultLibrary.updateWithdrawlQueue(
+      event.params.queue,
       ethTransaction,
       event
     );

--- a/src/mappings/yvWBTCVaultMappings.ts
+++ b/src/mappings/yvWBTCVaultMappings.ts
@@ -789,7 +789,7 @@ export function handleStrategyRemovedFromQueue(
 export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'yvWBTCVault_StrategyRemovedFromQueue',
+      'yvWBTCVault_UpdateWithdrawlQueue',
       event.block,
       YV_WBTC_VAULT_END_BLOCK_CUSTOM
     )

--- a/src/mappings/yvWBTCVaultMappings.ts
+++ b/src/mappings/yvWBTCVaultMappings.ts
@@ -791,7 +791,9 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(
+  event: UpdateWithdrawalQueue
+): void {
   if (
     isEventBlockNumberLt(
       'yvWBTCVault_UpdateWithdrawalQueue',

--- a/src/mappings/yvWBTCVaultMappings.ts
+++ b/src/mappings/yvWBTCVaultMappings.ts
@@ -23,6 +23,7 @@ import {
   UpdateManagement,
   UpdateGovernance,
   UpdateGuardian,
+  UpdateWithdrawalQueue,
 } from '../../generated/YvWBTCVault/Vault';
 import { Strategy, Transaction, Vault } from '../../generated/schema';
 import { isEventBlockNumberLt, printCallInfo } from '../utils/commons';
@@ -779,6 +780,27 @@ export function handleStrategyRemovedFromQueue(
     );
     vaultLibrary.strategyRemovedFromQueue(
       event.params.strategy,
+      ethTransaction,
+      event
+    );
+  }
+}
+
+export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+  if (
+    isEventBlockNumberLt(
+      'yvWBTCVault_StrategyRemovedFromQueue',
+      event.block,
+      YV_WBTC_VAULT_END_BLOCK_CUSTOM
+    )
+  ) {
+    let ethTransaction = getOrCreateTransactionFromEvent(
+      event,
+      'yvWBTCVault_UpdateWithdrawlQueue'
+    );
+
+    vaultLibrary.updateWithdrawlQueue(
+      event.params.queue,
       ethTransaction,
       event
     );

--- a/src/mappings/yvWBTCVaultMappings.ts
+++ b/src/mappings/yvWBTCVaultMappings.ts
@@ -791,20 +791,20 @@ export function handleStrategyRemovedFromQueue(
   }
 }
 
-export function handleUpdateWithdrawlQueue(event: UpdateWithdrawalQueue): void {
+export function handleUpdateWithdrawalQueue(event: UpdateWithdrawalQueue): void {
   if (
     isEventBlockNumberLt(
-      'yvWBTCVault_UpdateWithdrawlQueue',
+      'yvWBTCVault_UpdateWithdrawalQueue',
       event.block,
       YV_WBTC_VAULT_END_BLOCK_CUSTOM
     )
   ) {
     let ethTransaction = getOrCreateTransactionFromEvent(
       event,
-      'yvWBTCVault_UpdateWithdrawlQueue'
+      'yvWBTCVault_UpdateWithdrawalQueue'
     );
 
-    vaultLibrary.updateWithdrawlQueue(
+    vaultLibrary.UpdateWithdrawalQueue(
       event.params.queue,
       ethTransaction,
       event

--- a/src/mappings/yvWBTCVaultMappings.ts
+++ b/src/mappings/yvWBTCVaultMappings.ts
@@ -259,12 +259,17 @@ export function handleStrategyMigrated(event: StrategyMigrated): void {
           null,
           ethTransaction
         );
-        vaultLibrary.strategyRemovedFromQueue(
-          oldStrategyAddress,
-          ethTransaction,
-          event
-        );
       }
+      //We can now remove the old strat from the queue
+      log.info('[Strategy Migrated] Removing old strategy', [
+        oldStrategyAddress.toHexString(),
+      ]);
+
+      vaultLibrary.strategyRemovedFromQueue(
+        oldStrategyAddress,
+        ethTransaction,
+        event
+      );
     }
   }
 }

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -116,3 +116,17 @@ export function isEventBlockNumberLt(
 export function booleanToString(value: boolean): string {
   return value ? 'true' : 'false';
 }
+
+//Normaly i would use Array.filter for this but since AS does not supports closures i implemented this function
+//Returns the pointer to an new array without the specified element
+export function removeElementFromArray<T>(arr: Array<T>, e: T): Array<T> {
+  let newArr = new Array<T>();
+  for (let i = 0; i < arr.length; i++) {
+    let current = arr[i];
+    if (current == e) {
+      continue;
+    }
+    newArr.push(current);
+  }
+  return newArr;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,7 +71,7 @@ export let ETH_MAINNET_REGISTRY_ADDRESS_V2 =
   '0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804';
 export const ENDORSED = 'Endorsed';
 export const EXPERIMENTAL = 'Experimental';
-export const API_VERSION_0_4_3 = '0.4.3f';
+export const API_VERSION_0_4_3 = '0.4.3';
 export const API_VERSION_0_3_5 = '0.3.5';
 export const ETH_MAINNET_NETWORK = 'mainnet';
 export const FTM_MAINNET_NETWORK = 'fantom';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -72,6 +72,7 @@ export let ETH_MAINNET_REGISTRY_ADDRESS_V2 =
 export const ENDORSED = 'Endorsed';
 export const EXPERIMENTAL = 'Experimental';
 export const API_VERSION_0_4_3 = '0.4.3';
+export const API_VERSION_0_4_2 = '0.4.2';
 export const API_VERSION_0_3_5 = '0.3.5';
 export const ETH_MAINNET_NETWORK = 'mainnet';
 export const FTM_MAINNET_NETWORK = 'fantom';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,7 +71,7 @@ export let ETH_MAINNET_REGISTRY_ADDRESS_V2 =
   '0x50c1a2eA0a861A967D9d0FFE2AE4012c2E053804';
 export const ENDORSED = 'Endorsed';
 export const EXPERIMENTAL = 'Experimental';
-export const API_VERSION_0_4_2 = '0.4.2';
+export const API_VERSION_0_4_3 = '0.4.3f';
 export const API_VERSION_0_3_5 = '0.3.5';
 export const ETH_MAINNET_NETWORK = 'mainnet';
 export const FTM_MAINNET_NETWORK = 'fantom';

--- a/src/utils/strategy/strategy.ts
+++ b/src/utils/strategy/strategy.ts
@@ -88,6 +88,15 @@ export function createAndGet(
 
     strategy.save();
     StrategyTemplate.create(strategyAddress);
+
+    let vaultInstance = Vault.load(vault.toHexString());
+    if (vaultInstance != null) {
+      //Add the new strategy to the withdrawl queue of the vault
+      let withdrawlQueue = vaultInstance.withdrawalQueue;
+      withdrawlQueue.push(strategy.address.toHexString());
+      vaultInstance.withdrawalQueue = withdrawlQueue;
+      vaultInstance.save();
+    }
   }
   return strategy;
 }

--- a/src/utils/vault/vault.ts
+++ b/src/utils/vault/vault.ts
@@ -582,7 +582,6 @@ export function strategyRemovedFromQueue(
 
     let vault = Vault.load(event.address.toHexString());
     if (vault != null) {
-
       vault.withdrawalQueue = removeElementFromArray(
         vault.withdrawalQueue,
         strategy.address.toHexString()
@@ -590,6 +589,16 @@ export function strategyRemovedFromQueue(
 
       vault.save();
     }
+  }
+}
+
+export function updateWithdrawlQueue(
+  queue: Address[],
+  ethTransaction: Transaction,
+  event: ethereum.Event
+): void {
+  for (let i = 0; i < queue.length; i++) {
+    strategyAddedToQueue(queue[i], ethTransaction, event);
   }
 }
 

--- a/src/utils/vault/vault.ts
+++ b/src/utils/vault/vault.ts
@@ -26,7 +26,7 @@ import * as transferLibrary from '../transfer';
 import * as tokenLibrary from '../token';
 import * as registryLibrary from '../registry/registry';
 import { updateVaultDayData } from './vault-day-data';
-import { booleanToString } from '../commons';
+import { booleanToString, removeElementFromArray } from '../commons';
 import { getOrCreateHealthCheck } from '../healthCheck';
 
 const buildId = (vaultAddress: Address): string => {
@@ -579,6 +579,17 @@ export function strategyRemovedFromQueue(
   if (strategy !== null) {
     strategy.inQueue = false;
     strategy.save();
+
+    let vault = Vault.load(event.address.toHexString());
+    if (vault != null) {
+
+      vault.withdrawalQueue = removeElementFromArray(
+        vault.withdrawalQueue,
+        strategy.address.toHexString()
+      );
+
+      vault.save();
+    }
   }
 }
 

--- a/src/utils/vault/vault.ts
+++ b/src/utils/vault/vault.ts
@@ -595,7 +595,7 @@ export function strategyRemovedFromQueue(
   }
 }
 
-export function updateWithdrawlQueue(
+export function UpdateWithdrawalQueue(
   newQueue: Address[],
   ethTransaction: Transaction,
   event: ethereum.Event

--- a/src/utils/vault/vault.ts
+++ b/src/utils/vault/vault.ts
@@ -559,7 +559,10 @@ export function strategyAddedToQueue(
     if (vault != null) {
       //Add the new strategy to the withdrawl queue
       let withdrawlQueue = vault.withdrawalQueue;
-      withdrawlQueue.push(strategy.address.toHexString());
+      //Only add strategy to queue when its not was previously added
+      if (!withdrawlQueue.includes(strategy.address.toHexString())) {
+        withdrawlQueue.push(strategy.address.toHexString());
+      }
       vault.withdrawalQueue = withdrawlQueue;
 
       vault.save();

--- a/src/utils/vault/vault.ts
+++ b/src/utils/vault/vault.ts
@@ -84,6 +84,9 @@ const createNewVaultFromAddress = (
   vaultEntity.activation = vaultContract.activation();
   vaultEntity.apiVersion = vaultContract.apiVersion();
 
+  //Empty at creation
+  vaultEntity.withdrawalQueue = [];
+
   return vaultEntity;
 };
 
@@ -551,6 +554,16 @@ export function strategyAddedToQueue(
   if (strategy !== null) {
     strategy.inQueue = true;
     strategy.save();
+
+    let vault = Vault.load(event.address.toHexString());
+    if (vault != null) {
+      //Add the new strategy to the withdrawl queue
+      let withdrawlQueue = vault.withdrawalQueue;
+      withdrawlQueue.push(strategy.address.toHexString());
+      vault.withdrawalQueue = withdrawlQueue;
+
+      vault.save();
+    }
   }
 }
 

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -189,7 +189,7 @@ dataSources:
         - event: StrategyRemovedFromQueue(indexed address)
           handler: handleStrategyRemovedFromQueue
         - event : UpdateWithdrawalQueue(address[20])
-          handler : handleUpdateWithdrawlQueue
+          handler : handleUpdateWithdrawalQueue
         - event: UpdateRewards(address)
           handler: handleUpdateRewards
         - event: Deposit(indexed address,uint256,uint256)
@@ -289,7 +289,7 @@ templates:
         - event: StrategyRemovedFromQueue(indexed address)
           handler: handleStrategyRemovedFromQueue
         - event : UpdateWithdrawalQueue(address[20])
-          handler : handleUpdateWithdrawlQueue
+          handler : handleUpdateWithdrawalQueue
         - event: UpdateRewards(address)
           handler: handleUpdateRewards
         - event: Deposit(indexed address,uint256,uint256)

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -188,7 +188,7 @@ dataSources:
           handler: handleStrategyAddedToQueue
         - event: StrategyRemovedFromQueue(indexed address)
           handler: handleStrategyRemovedFromQueue
-        - event : UpdateWithdrawalQueue(address[20])
+        - event : UpdateWithdrawalQueue(address[])
           handler : handleUpdateWithdrawlQueue
         - event: UpdateRewards(address)
           handler: handleUpdateRewards
@@ -288,7 +288,7 @@ templates:
           handler: handleStrategyAddedToQueue
         - event: StrategyRemovedFromQueue(indexed address)
           handler: handleStrategyRemovedFromQueue
-        - event : UpdateWithdrawalQueue(address[20])
+        - event : UpdateWithdrawalQueue(address[])
           handler : handleUpdateWithdrawlQueue
         - event: UpdateRewards(address)
           handler: handleUpdateRewards

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -188,6 +188,8 @@ dataSources:
           handler: handleStrategyAddedToQueue
         - event: StrategyRemovedFromQueue(indexed address)
           handler: handleStrategyRemovedFromQueue
+        - event : UpdateWithdrawalQueue(address[20])
+          handler : handleUpdateWithdrawlQueue
         - event: UpdateRewards(address)
           handler: handleUpdateRewards
         - event: Deposit(indexed address,uint256,uint256)
@@ -286,6 +288,8 @@ templates:
           handler: handleStrategyAddedToQueue
         - event: StrategyRemovedFromQueue(indexed address)
           handler: handleStrategyRemovedFromQueue
+        - event : UpdateWithdrawalQueue(address[20])
+          handler : handleUpdateWithdrawlQueue
         - event: UpdateRewards(address)
           handler: handleUpdateRewards
         - event: Deposit(indexed address,uint256,uint256)

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -188,7 +188,7 @@ dataSources:
           handler: handleStrategyAddedToQueue
         - event: StrategyRemovedFromQueue(indexed address)
           handler: handleStrategyRemovedFromQueue
-        - event : UpdateWithdrawalQueue(address[])
+        - event : UpdateWithdrawalQueue(address[20])
           handler : handleUpdateWithdrawlQueue
         - event: UpdateRewards(address)
           handler: handleUpdateRewards
@@ -288,7 +288,7 @@ templates:
           handler: handleStrategyAddedToQueue
         - event: StrategyRemovedFromQueue(indexed address)
           handler: handleStrategyRemovedFromQueue
-        - event : UpdateWithdrawalQueue(address[])
+        - event : UpdateWithdrawalQueue(address[20])
           handler : handleUpdateWithdrawlQueue
         - event: UpdateRewards(address)
           handler: handleUpdateRewards

--- a/tests/depositAndWithdrawl.test.ts
+++ b/tests/depositAndWithdrawl.test.ts
@@ -22,6 +22,7 @@ import {
   handleWithdrawEvent,
 } from '../src/mappings/vaultMappings';
 import { TokenStub } from './stubs/tokenStateStub';
+import { BIGINT_MAX, MAX_UINT } from '../src/utils/constants';
 
 test('Test handleDeposit (call)', () => {
   clearStore();
@@ -144,7 +145,7 @@ test('Test handleDepositWithAmountAndRecipient (call)', () => {
 test('Test handleWithdraw (call)', () => {
   clearStore();
   // set up the deposit
-  let amount = '79056085';
+  let amount = BIGINT_MAX.toString();
   let shareTokenBalances = new Map<string, string>();
   let sender = defaults.senderAddress;
   let vaultAddress = VaultStub.DefaultAddress;

--- a/tests/depositAndWithdrawl.test.ts
+++ b/tests/depositAndWithdrawl.test.ts
@@ -235,7 +235,8 @@ test('Deposit call handlers shouldnt fire if Vault apiVersion > 0.4.3', () => {
         wantTokenBalances, // token balances
         null, // token usdc value
         null // price oracle address
-      )
+      ),
+      null //withdrawlQueue
     ),
     null, //registryAddress
     null, //releaseId
@@ -305,7 +306,8 @@ test('Withdraw call handlers shouldnt fire if Vault apiVersion > 0.4.3', () => {
         wantTokenBalances, // token balances
         null, // token usdc value
         null // price oracle address
-      )
+      ),
+      null //withdrawlQueue
     ),
     null, //registryAddress
     null, //releaseId

--- a/tests/mappingParamBuilders/updateWithdrawlQueueParamBuilder.ts
+++ b/tests/mappingParamBuilders/updateWithdrawlQueueParamBuilder.ts
@@ -1,0 +1,53 @@
+import { Address, ethereum, BigInt } from '@graphprotocol/graph-ts';
+import { fatalTestError } from '../util';
+import { MockBlock } from './mockBlock';
+import { MockTransaction } from './mockTransaction';
+import { ParamFactoryBase } from './paramFactoryBase';
+
+/**
+ * This class is used to dynamically create trigger mocks. It can only create triggers for events that have a single param representing an updated value, of which we have quite a few.
+ * Eventually, we should add a way to codegen all of the mappingParamBuilders so this can be removed.
+ */
+export class UpdateWithdrawalQueueParamBuilder<
+  EventTrigger
+> extends ParamFactoryBase {
+  subjectAddress: string;
+  newValue: string[];
+
+  mock: EventTrigger;
+
+  constructor(
+    subjectAddress: string,
+    newValue: string[],
+    transaction: MockTransaction | null,
+    mockBlock: MockBlock | null
+  ) {
+    super(transaction, mockBlock);
+    this.subjectAddress = subjectAddress;
+    this.newValue = newValue;
+
+    // create the mock itself
+    let eventParams = new Array<ethereum.EventParam>();
+
+    eventParams.push(
+      new ethereum.EventParam(
+        'param',
+        ethereum.Value.fromAddressArray(
+          newValue.map<Address>((v: string) => Address.fromString(v))
+        )
+      )
+    );
+
+    let event = instantiate<EventTrigger>(
+      Address.fromString(this.subjectAddress),
+      BigInt.fromString(this.transaction.logIndex),
+      BigInt.fromString(this.transaction.txnIndex),
+      'default_log_type',
+      this.block.mock,
+      this.transaction.mock,
+      eventParams
+    );
+
+    this.mock = event;
+  }
+}

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -30,7 +30,8 @@ test('Test handleNewRelease', () => {
     null, // depositLimit
     null, // availableDepositLimit
     TokenStub.DefaultToken(VaultStub.DefaultAddress), // shareToken
-    TokenStub.DefaultToken(TokenStub.DefaultTokenAddress) // wantToken
+    TokenStub.DefaultToken(TokenStub.DefaultTokenAddress), // wantToken
+    null //withdrawlQueue
   );
 
   let newReleaseEvent = new NewReleaseEventBuilder(

--- a/tests/strategy.test.ts
+++ b/tests/strategy.test.ts
@@ -365,18 +365,38 @@ test('Test UpdatedRewards Event', () => {
   assert.fieldEquals('Strategy', strategyAddress, 'rewards', newRewardsAddress);
 });
 
+test('Test strategyAddedV1', () => {
+  clearStore();
+  let vault = CreateVaultTransition.DefaultVault();
+  let vaultAddress = vault.stub.address;
+
+
+  let strategy = CreateStrategyTransition.DefaultStrategyWithDebt(
+    vault.stub,
+    '100000'
+  );
+  
+
+  assert.fieldEquals(
+    'Vault',
+    vaultAddress,
+    'withdrawalQueue',
+    '[' + strategy.stub.address.toString() + ']'
+  );
+});
+
+
+
 test('Test strategyAddedToQueue Event', () => {
   clearStore();
   let vault = CreateVaultTransition.DefaultVault();
   let vaultAddress = vault.stub.address;
 
   assert.i32Equals(vault.stub.withDrawlQueue.length, 0);
-
   assert.fieldEquals('Vault', vaultAddress, 'withdrawalQueue', '[]');
 
   let strategy = CreateStrategyTransition.DefaultStrategy(vault.stub);
 
-  assert.fieldEquals('Vault', vaultAddress, 'withdrawalQueue', '[]');
 
   new MockStrategyAddedToQueueTransition(vault.stub, strategy.stub.address);
 
@@ -406,23 +426,22 @@ test('Test setWithdrawlQueue Event', () => {
     defaults.anotherAddress
   );
 
-  assert.fieldEquals('Vault', vaultAddress, 'withdrawalQueue', '[]');
 
   new MockUpdateWithdrawlQueueTransition(vault.stub, [
     firstStrategy.stub.address,
     secondStrategy.stub.address,
   ]);
 
+
   let vaultWithNewWithdrawlQueue = Vault.load(vault.stub.address);
   assert.i32Equals(vaultWithNewWithdrawlQueue!.withdrawalQueue.length, 2);
-   
+
   let actualFirstStrat = vaultWithNewWithdrawlQueue!.withdrawalQueue[0];
   let actualSecondStrat = vaultWithNewWithdrawlQueue!.withdrawalQueue[1];
 
-
   //Ensure that both strategy are part of the withdrawlQueue before we delete the first one
   assert.stringEquals(firstStrategy.stub.address, actualFirstStrat);
-  assert.stringEquals(secondStrategy.stub.address, actualSecondStrat); 
+  assert.stringEquals(secondStrategy.stub.address, actualSecondStrat);
 });
 
 test('Test strategyRemovedFromQueue Event', () => {
@@ -439,6 +458,7 @@ test('Test strategyRemovedFromQueue Event', () => {
   //Add First strategy
   new MockStrategyAddedToQueueTransition(
     vault.stub,
+
     firstStrategy.stub.address
   );
 
@@ -461,6 +481,8 @@ test('Test strategyRemovedFromQueue Event', () => {
     vault.stub,
     firstStrategy.stub.address
   );
+
+
   //Withdrawl Queue now only contains the second strat
   assert.fieldEquals(
     'Vault',

--- a/tests/strategy.test.ts
+++ b/tests/strategy.test.ts
@@ -519,5 +519,3 @@ test('Test strategyRemovedFromQueue Event', () => {
     '[' + secondStrategy.stub.address.toString() + ']'
   );
 });
-
-

--- a/tests/strategy.test.ts
+++ b/tests/strategy.test.ts
@@ -370,12 +370,10 @@ test('Test strategyAddedV1', () => {
   let vault = CreateVaultTransition.DefaultVault();
   let vaultAddress = vault.stub.address;
 
-
   let strategy = CreateStrategyTransition.DefaultStrategyWithDebt(
     vault.stub,
     '100000'
   );
-  
 
   assert.fieldEquals(
     'Vault',
@@ -384,8 +382,6 @@ test('Test strategyAddedV1', () => {
     '[' + strategy.stub.address.toString() + ']'
   );
 });
-
-
 
 test('Test strategyAddedToQueue Event', () => {
   clearStore();
@@ -396,7 +392,6 @@ test('Test strategyAddedToQueue Event', () => {
   assert.fieldEquals('Vault', vaultAddress, 'withdrawalQueue', '[]');
 
   let strategy = CreateStrategyTransition.DefaultStrategy(vault.stub);
-
 
   new MockStrategyAddedToQueueTransition(vault.stub, strategy.stub.address);
 
@@ -426,12 +421,10 @@ test('Test setWithdrawlQueue Event', () => {
     defaults.anotherAddress
   );
 
-
   new MockUpdateWithdrawlQueueTransition(vault.stub, [
     firstStrategy.stub.address,
     secondStrategy.stub.address,
   ]);
-
 
   let vaultWithNewWithdrawlQueue = Vault.load(vault.stub.address);
   assert.i32Equals(vaultWithNewWithdrawlQueue!.withdrawalQueue.length, 2);
@@ -481,7 +474,6 @@ test('Test strategyRemovedFromQueue Event', () => {
     vault.stub,
     firstStrategy.stub.address
   );
-
 
   //Withdrawl Queue now only contains the second strat
   assert.fieldEquals(

--- a/tests/strategy.test.ts
+++ b/tests/strategy.test.ts
@@ -26,7 +26,7 @@ import { Vault } from '../generated/schema';
 import {
   MockStrategyAddedToQueueTransition,
   MockStrategyRemovedFromQueueTransition,
-  MockUpdateWithdrawlQueueTransition,
+  MockUpdateWithdrawalQueueTransition,
 } from './transitionMocks/vaultAttributeTransitions';
 
 test('Test handleHarvested Event', () => {
@@ -421,7 +421,7 @@ test('Test setWithdrawlQueue Event', () => {
     defaults.anotherAddress
   );
 
-  new MockUpdateWithdrawlQueueTransition(vault.stub, [
+  new MockUpdateWithdrawalQueueTransition(vault.stub, [
     firstStrategy.stub.address,
     secondStrategy.stub.address,
   ]);
@@ -447,7 +447,7 @@ test('Test setWithdrawlQueue Event -- new withdrawlQueue should not contain stra
 
   let firstStrategy = CreateStrategyTransition.DefaultStrategy(vault.stub);
 
-  new MockUpdateWithdrawlQueueTransition(vault.stub, [
+  new MockUpdateWithdrawalQueueTransition(vault.stub, [
     firstStrategy.stub.address,
   ]);
 
@@ -462,7 +462,7 @@ test('Test setWithdrawlQueue Event -- new withdrawlQueue should not contain stra
     defaults.anotherAddress
   );
   //Because we are setting the queue "firstStrat" is no longer part of the withdrawlQueue
-  new MockUpdateWithdrawlQueueTransition(vault.stub, [
+  new MockUpdateWithdrawalQueueTransition(vault.stub, [
     secondStrategy.stub.address,
   ]);
 
@@ -519,3 +519,5 @@ test('Test strategyRemovedFromQueue Event', () => {
     '[' + secondStrategy.stub.address.toString() + ']'
   );
 });
+
+

--- a/tests/strategy.test.ts
+++ b/tests/strategy.test.ts
@@ -23,6 +23,7 @@ import {
 import { getDayIDFromIndex } from '../src/utils/vault/vault-day-data';
 import { BIGINT_ZERO } from '../src/utils/constants';
 import { Vault } from '../generated/schema';
+import { MockStrategyAddedToQueueTransition } from './transitionMocks/vaultAttributeTransitions';
 
 test('Test handleHarvested Event', () => {
   clearStore();
@@ -358,4 +359,33 @@ test('Test UpdatedRewards Event', () => {
     newRewardsAddress
   );
   assert.fieldEquals('Strategy', strategyAddress, 'rewards', newRewardsAddress);
+});
+
+test('Test strategyAddedToQueue Event', () => {
+  clearStore();
+  let vault = CreateVaultTransition.DefaultVault();
+  let vaultAddress = vault.stub.address;
+
+  let oldWithdrawlQueue = new Array<string>();
+
+  assert.i32Equals(oldWithdrawlQueue.length, 0);
+
+  assert.fieldEquals('Vault', vaultAddress, 'withdrawalQueue', '[]');
+
+  let strategy = CreateStrategyTransition.DefaultStrategy(vault.stub);
+
+  assert.fieldEquals('Vault', vaultAddress, 'withdrawalQueue', '[]');
+
+  new MockStrategyAddedToQueueTransition(vault.stub, strategy.stub.address);
+
+  let expectedWithdrawlQueue = new Array<string>();
+  expectedWithdrawlQueue.push(strategy.stub.address);
+
+  
+  assert.fieldEquals(
+    'Vault',
+    vaultAddress,
+    'withdrawalQueue',
+    '[' + expectedWithdrawlQueue.toString() + ']'
+  );
 });

--- a/tests/stubs/vaultStateStub.ts
+++ b/tests/stubs/vaultStateStub.ts
@@ -165,10 +165,12 @@ export class VaultStub extends GenericStateStub {
       Address.fromString(this.address),
       'withdrawalQueue',
       'withdrawalQueue'.concat('(uint256):(address)')
-    ).returns(
+    ).returns([
       //@ts-ignore
-      [ethereum.Value.fromAddressArray(value.map<Address>((v:string) => Address.fromString(v)))]
-    );
+      ethereum.Value.fromAddressArray(
+        value.map<Address>((v: string) => Address.fromString(v))
+      ),
+    ]);
     this._withDrawlQueue = value;
   }
 

--- a/tests/stubs/vaultStateStub.ts
+++ b/tests/stubs/vaultStateStub.ts
@@ -1,12 +1,8 @@
-import { Address, ethereum, BigInt } from '@graphprotocol/graph-ts';
+import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
 import { createMockedFunction } from 'matchstick-as';
-import { Vault } from '../../generated/Registry/Vault';
-import { Token } from '../../generated/schema';
 import { defaults } from '../default';
-import { fatalTestError } from '../util';
 import { GenericStateStub } from './genericStateStub';
 import { TokenStub } from './tokenStateStub';
-import { log } from 'matchstick-as/assembly/log';
 
 export class VaultStub extends GenericStateStub {
   static DefaultAddress: string = defaults.vaultAddress;
@@ -28,7 +24,8 @@ export class VaultStub extends GenericStateStub {
       null, // depositLimit
       null, // availableDepositLimit
       TokenStub.DefaultToken(VaultStub.DefaultAddress),
-      TokenStub.DefaultToken(TokenStub.DefaultTokenAddress)
+      TokenStub.DefaultToken(TokenStub.DefaultTokenAddress),
+      null //withdrawlQueue
     );
   }
 
@@ -158,6 +155,23 @@ export class VaultStub extends GenericStateStub {
     this._availableDepositLimit = value;
   }
 
+  private _withDrawlQueue: Array<string>;
+  public get withDrawlQueue(): Array<string> {
+    return this._withDrawlQueue;
+  }
+
+  public set withDrawlQueue(value: Array<string>) {
+    createMockedFunction(
+      Address.fromString(this.address),
+      'withdrawalQueue',
+      'withdrawalQueue'.concat('(uint256):(address)')
+    ).returns(
+      //@ts-ignore
+      [ethereum.Value.fromAddressArray(value.map((v) => Address.fromString(v)))]
+    );
+    this._withDrawlQueue = value;
+  }
+
   shareToken: TokenStub;
   wantToken: TokenStub;
 
@@ -178,7 +192,8 @@ export class VaultStub extends GenericStateStub {
       this.depositLimit,
       this.availableDepositLimit,
       this.shareToken,
-      this.wantToken
+      this.wantToken,
+      this.withDrawlQueue
     );
   }
 
@@ -198,7 +213,8 @@ export class VaultStub extends GenericStateStub {
     depositLimit: string | null,
     availableDepositLimit: string | null,
     shareToken: TokenStub,
-    wantToken: TokenStub
+    wantToken: TokenStub,
+    withDrawlQueue: Array<string> | null
   ) {
     super(shareToken.address);
     this.shareToken = shareToken;
@@ -274,6 +290,11 @@ export class VaultStub extends GenericStateStub {
       this._availableDepositLimit = availableDepositLimit;
     } else {
       this._availableDepositLimit = '100';
+    }
+    if (withDrawlQueue) {
+      this._withDrawlQueue = withDrawlQueue;
+    } else {
+      this._withDrawlQueue = new Array();
     }
 
     // update stubs by triggering each field's setter

--- a/tests/stubs/vaultStateStub.ts
+++ b/tests/stubs/vaultStateStub.ts
@@ -167,7 +167,7 @@ export class VaultStub extends GenericStateStub {
       'withdrawalQueue'.concat('(uint256):(address)')
     ).returns(
       //@ts-ignore
-      [ethereum.Value.fromAddressArray(value.map((v) => Address.fromString(v)))]
+      [ethereum.Value.fromAddressArray(value.map<Address>((v:string) => Address.fromString(v)))]
     );
     this._withDrawlQueue = value;
   }

--- a/tests/transitionMocks/createStrategyTransition.ts
+++ b/tests/transitionMocks/createStrategyTransition.ts
@@ -10,10 +10,13 @@ import { handleStrategyAddedV1 } from '../../src/mappings/vaultMappings';
 export class CreateStrategyTransition {
   static DefaultAddress: string = StrategyStub.DefaultAddress;
 
-  static DefaultStrategy(vaultStub: VaultStub): CreateStrategyTransition {
+  static DefaultStrategy(
+    vaultStub: VaultStub,
+    address: string = StrategyStub.DefaultAddress
+  ): CreateStrategyTransition {
     let strategyStub = new StrategyStub(
       null,
-      null,
+      address,
       vaultStub.shareToken.address,
       null,
       true,

--- a/tests/transitionMocks/createStrategyTransition.ts
+++ b/tests/transitionMocks/createStrategyTransition.ts
@@ -108,10 +108,7 @@ export class CreateStrategyTransition {
       null
     );
 
-    
     handleStrategyAddedV1(this.mockEvent.mock);
     MockBlock.IncrementBlock();
   }
-
-
 }

--- a/tests/transitionMocks/createStrategyTransition.ts
+++ b/tests/transitionMocks/createStrategyTransition.ts
@@ -50,7 +50,7 @@ export class CreateStrategyTransition {
       true,
       vaultStub.wantToken,
       null,
-      null,
+      false,
       false,
       null,
       null,
@@ -77,7 +77,8 @@ export class CreateStrategyTransition {
     debtLimit: string | null,
     rateLimit: string | null,
     performanceFee: string | null,
-    stub: StrategyStub | null
+    stub: StrategyStub | null,
+    version: string = 'v1'
   ) {
     if (stub) {
       this.stub = stub;
@@ -107,7 +108,10 @@ export class CreateStrategyTransition {
       null
     );
 
+    
     handleStrategyAddedV1(this.mockEvent.mock);
     MockBlock.IncrementBlock();
   }
+
+
 }

--- a/tests/transitionMocks/createVaultTransition.ts
+++ b/tests/transitionMocks/createVaultTransition.ts
@@ -42,7 +42,8 @@ export class CreateVaultTransition {
           null, // token balances
           null, // token usdc value
           null // price oracle address
-        )
+        ),
+        null // withDrawlQueue
       ),
       null, // registryAddress
       null, // releaseId
@@ -90,7 +91,8 @@ export class CreateVaultTransition {
         wantTokenBalances, // token balances
         null, // token usdc value
         null // price oracle address
-      )
+      ),
+      null
     );
 
     return new CreateVaultTransition(
@@ -138,7 +140,8 @@ export class CreateVaultTransition {
         wantTokenBalances, // token balances
         null, // token usdc value
         null // price oracle address
-      )
+      ),
+      null
     );
 
     return new CreateVaultTransition(
@@ -187,7 +190,8 @@ export class CreateVaultTransition {
         null, // depositLimit
         null, // availableDepositLimit
         shareToken, // shareToken
-        wantToken // wantToken
+        wantToken, // wantToken
+        null //withdrawlQueue
       );
     }
 

--- a/tests/transitionMocks/genericDepositTransition.ts
+++ b/tests/transitionMocks/genericDepositTransition.ts
@@ -93,7 +93,8 @@ export class GenericDepositTransition {
       preDepositStub.depositLimit, // depositLimit
       preDepositStub.availableDepositLimit, // availableDepositLimit
       newShareTokenStub.postTransitionStub, // postTransitionStub
-      newWantTokenStub.postTransitionStub // postTransitionStub
+      newWantTokenStub.postTransitionStub, // postTransitionStub
+      preDepositStub.withDrawlQueue // withdrawlQueue
     );
 
     // now trigger the transfer handlers that we skipped earlier

--- a/tests/transitionMocks/genericWithdrawTransition.ts
+++ b/tests/transitionMocks/genericWithdrawTransition.ts
@@ -70,7 +70,8 @@ export class GenericWithdrawTransition {
       preWithdrawStub.depositLimit, // depositLimit
       preWithdrawStub.availableDepositLimit, // availableDepositLimit
       newShareTokenStub.postTransitionStub,
-      newWantTokenStub.postTransitionStub
+      newWantTokenStub.postTransitionStub,
+      preWithdrawStub.withDrawlQueue
     );
 
     // now trigger the transfer handlers that we skipped earlier

--- a/tests/transitionMocks/vaultAttributeTransitions.ts
+++ b/tests/transitionMocks/vaultAttributeTransitions.ts
@@ -9,12 +9,14 @@ import {
   handleUpdateManagementFee,
   handleUpdatePerformanceFee,
   handleUpdateRewards,
+  handleUpdateWithdrawlQueue,
 } from '../../src/mappings/vaultMappings';
 import { MockBlock } from '../mappingParamBuilders/mockBlock';
 import { VaultStub } from '../stubs/vaultStateStub';
 import {
   StrategyAddedToQueue,
   StrategyRemovedFromQueue,
+  UpdateWithdrawalQueue,
   UpdateDepositLimit,
   UpdateGovernance,
   UpdateGuardian,
@@ -25,6 +27,7 @@ import {
 } from '../../generated/Registry/Vault';
 import { GenericAttributeUpdateEvent } from '../mappingParamBuilders/genericUpdateParam';
 import { removeElementFromArray } from '../../src/utils/commons';
+import { UpdateWithdrawalQueueParamBuilder } from '../mappingParamBuilders/updateWithdrawlQueueParamBuilder';
 
 export class MockUpdateManagementFeeTransition {
   mockEvent: GenericAttributeUpdateEvent<UpdateManagementFee, BigInt>;
@@ -216,6 +219,30 @@ export class MockStrategyAddedToQueueTransition {
     >(preTransitionStub.shareToken.address, strategyAdded, null, null);
 
     handleStrategyAddedToQueue(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+export class MockUpdateWithdrawlQueueTransition {
+  mockEvent: UpdateWithdrawalQueueParamBuilder<UpdateWithdrawalQueue>;
+  preTransitionStub: VaultStub;
+  postTransitionStub: VaultStub;
+
+  constructor(preTransitionStub: VaultStub, newWithdrawlQueue: string[]) {
+    this.preTransitionStub = preTransitionStub;
+    let postTransitionStub = preTransitionStub.clone();
+
+    postTransitionStub.withDrawlQueue = newWithdrawlQueue;
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new UpdateWithdrawalQueueParamBuilder<UpdateWithdrawalQueue>(
+      preTransitionStub.shareToken.address,
+      newWithdrawlQueue,
+      null,
+      null
+    );
+
+    handleUpdateWithdrawlQueue(this.mockEvent.mock);
 
     MockBlock.IncrementBlock();
   }

--- a/tests/transitionMocks/vaultAttributeTransitions.ts
+++ b/tests/transitionMocks/vaultAttributeTransitions.ts
@@ -1,6 +1,7 @@
 import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
 import {
   handleStrategyAddedToQueue,
+  handleStrategyRemovedFromQueue,
   handleUpdateDepositLimit,
   handleUpdateGovernance,
   handleUpdateGuardian,
@@ -13,6 +14,7 @@ import { MockBlock } from '../mappingParamBuilders/mockBlock';
 import { VaultStub } from '../stubs/vaultStateStub';
 import {
   StrategyAddedToQueue,
+  StrategyRemovedFromQueue,
   UpdateDepositLimit,
   UpdateGovernance,
   UpdateGuardian,
@@ -22,6 +24,7 @@ import {
   UpdateRewards,
 } from '../../generated/Registry/Vault';
 import { GenericAttributeUpdateEvent } from '../mappingParamBuilders/genericUpdateParam';
+import { removeElementFromArray } from '../../src/utils/commons';
 
 export class MockUpdateManagementFeeTransition {
   mockEvent: GenericAttributeUpdateEvent<UpdateManagementFee, BigInt>;
@@ -213,6 +216,31 @@ export class MockStrategyAddedToQueueTransition {
     >(preTransitionStub.shareToken.address, strategyAdded, null, null);
 
     handleStrategyAddedToQueue(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+export class MockStrategyRemovedFromQueueTransition {
+  mockEvent: GenericAttributeUpdateEvent<StrategyRemovedFromQueue, Address>;
+  preTransitionStub: VaultStub;
+  postTransitionStub: VaultStub;
+
+  constructor(preTransitionStub: VaultStub, strategyRemoved: string) {
+    this.preTransitionStub = preTransitionStub;
+    let postTransitionStub = preTransitionStub.clone();
+
+    postTransitionStub.withDrawlQueue = removeElementFromArray(
+      postTransitionStub.withDrawlQueue,
+      strategyRemoved
+    );
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new GenericAttributeUpdateEvent<
+      StrategyRemovedFromQueue,
+      Address
+    >(preTransitionStub.shareToken.address, strategyRemoved, null, null);
+
+    handleStrategyRemovedFromQueue(this.mockEvent.mock);
 
     MockBlock.IncrementBlock();
   }

--- a/tests/transitionMocks/vaultAttributeTransitions.ts
+++ b/tests/transitionMocks/vaultAttributeTransitions.ts
@@ -1,5 +1,6 @@
 import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
 import {
+  handleStrategyAddedToQueue,
   handleUpdateDepositLimit,
   handleUpdateGovernance,
   handleUpdateGuardian,
@@ -11,6 +12,7 @@ import {
 import { MockBlock } from '../mappingParamBuilders/mockBlock';
 import { VaultStub } from '../stubs/vaultStateStub';
 import {
+  StrategyAddedToQueue,
   UpdateDepositLimit,
   UpdateGovernance,
   UpdateGuardian,
@@ -185,6 +187,32 @@ export class MockUpdateDepositLimitTransition {
     >(preTransitionStub.shareToken.address, depositLimit, null, null);
 
     handleUpdateDepositLimit(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+
+export class MockStrategyAddedToQueueTransition {
+  mockEvent: GenericAttributeUpdateEvent<StrategyAddedToQueue, Address>;
+  preTransitionStub: VaultStub;
+  postTransitionStub: VaultStub;
+
+  constructor(preTransitionStub: VaultStub, strategyAdded: string) {
+    this.preTransitionStub = preTransitionStub;
+    let postTransitionStub = preTransitionStub.clone();
+
+    let withDrawlQueue = postTransitionStub.withDrawlQueue;
+    withDrawlQueue.push(strategyAdded);
+
+    postTransitionStub.withDrawlQueue = withDrawlQueue;
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new GenericAttributeUpdateEvent<
+      StrategyAddedToQueue,
+      Address
+    >(preTransitionStub.shareToken.address, strategyAdded, null, null);
+
+    handleStrategyAddedToQueue(this.mockEvent.mock);
 
     MockBlock.IncrementBlock();
   }

--- a/tests/transitionMocks/vaultAttributeTransitions.ts
+++ b/tests/transitionMocks/vaultAttributeTransitions.ts
@@ -9,7 +9,7 @@ import {
   handleUpdateManagementFee,
   handleUpdatePerformanceFee,
   handleUpdateRewards,
-  handleUpdateWithdrawlQueue,
+  handleUpdateWithdrawalQueue,
 } from '../../src/mappings/vaultMappings';
 import { MockBlock } from '../mappingParamBuilders/mockBlock';
 import { VaultStub } from '../stubs/vaultStateStub';
@@ -223,7 +223,7 @@ export class MockStrategyAddedToQueueTransition {
     MockBlock.IncrementBlock();
   }
 }
-export class MockUpdateWithdrawlQueueTransition {
+export class MockUpdateWithdrawalQueueTransition {
   mockEvent: UpdateWithdrawalQueueParamBuilder<UpdateWithdrawalQueue>;
   preTransitionStub: VaultStub;
   postTransitionStub: VaultStub;
@@ -242,7 +242,7 @@ export class MockUpdateWithdrawlQueueTransition {
       null
     );
 
-    handleUpdateWithdrawlQueue(this.mockEvent.mock);
+    handleUpdateWithdrawalQueue(this.mockEvent.mock);
 
     MockBlock.IncrementBlock();
   }


### PR DESCRIPTION
This pr is about to add the field withdrawlQueue in order to do this I've

-Added the field withdrawlQueue
- Added a new event handler called "handleUpdateWithdrawlQueue" that takes the address array of the event and stores it as the new withdrawal queue
- strategyAddedToQueue now pushes the newly added strategy at the end of the withdrawal queue
- strategyRemovedFromQueue now removes the related strategy from the withdrawal queue
- Extended the strategies test suite to test those handlers
- Added also handleUpdateWithdrawlQueue also to the custom mappings of ftm and mainnet

